### PR TITLE
Easier resolver config

### DIFF
--- a/etc/loris.conf
+++ b/etc/loris.conf
@@ -30,7 +30,8 @@ max_size=5242880 ; 5 MB
 max_backups=5
 format=%(asctime)s (%(name)s) [%(levelname)s]: %(message)s
 
-[resolver.Resolver] 
+[resolver]
+impl=SimpleFSResolver
 src_img_root=/usr/local/share/images
 
 [img.ImageCache]

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -4,118 +4,116 @@
 ================================================
 """
 from logging import getLogger
+import loris_exception
 from os.path import join, exists, isfile
 from urllib import unquote
-
-import loris_exception
+from shutil import copy
+from os import makedirs
+from os.path import dirname
 
 logger = getLogger(__name__)
 
 class _AbstractResolver(object):
-	def __init__(self, config):
-		self.config = config
+    def __init__(self, config):
+        self.config = config
 
-	def is_resolvable(self, ident):
-		"""
-		The idea here is that in some scenarios it may be cheaper to check 
-		that an id is resolvable than to actually resolve it and retrieve or
-		calculate the fp.
+    def is_resolvable(self, ident):
+        """
+        The idea here is that in some scenarios it may be cheaper to check 
+        that an id is resolvable than to actually resolve it and retrieve or
+        calculate the fp.
 
-		Args:
-			ident (str):
-				The identifier for the image.
-		Returns:
-			bool
-		"""
-		e = self.__class__.__name__
-		raise NotImplementedError('is_resolvable() not implemented for %s' % (cn,))
+        Args:
+            ident (str):
+                The identifier for the image.
+        Returns:
+            bool
+        """
+        e = self.__class__.__name__
+        raise NotImplementedError('is_resolvable() not implemented for %s' % (cn,))
 
-	def resolve(self, ident):
-		"""
-		Given the identifier of an image, get the path (fp) and format. This 
-		will likely	need to be reimplemented overridden to suit different 
-		environments and can be as smart or dumb as you want.
-		
-		Args:
-			ident (str):
-				The identifier for the image.
-		Returns:
-			(str, str): (fp, format)
-		Raises:
-			ResolverException when something goes wrong...
-		"""
-		e = self.__class__.__name__
-		raise NotImplementedError('resolve() not implemented for %s' % (cn,))
-
-
-class Resolver(_AbstractResolver):
-	def __init__(self, config):
-		super(Resolver, self).__init__(config)
-		self.cache_root = self.config['src_img_root']
-
-	def is_resolvable(self, ident):
-		ident = unquote(ident)
-		fp = join(self.cache_root, ident)
-		return exists(fp)
-
-	@staticmethod
-	def _format_from_ident(ident):
-		return ident.split('.')[-1]
-
-	def resolve(self, ident):
-		# For this dumb version a constant path is prepended to the identfier 
-		# supplied to get the path It assumes this 'identifier' ends with a file 
-		# extension from which the format is then derived.
-		ident = unquote(ident)
-		fp = join(self.cache_root, ident)
-		logger.debug('src image: %s' % (fp,))
-
-		if not exists(fp):
-			public_message = 'Source image not found for identifier: %s.' % (ident,)
-			log_message = 'Source image not found at %s for identifier: %s.' % (fp,ident)
-			logger.warn(log_message)
-			raise ResolverException(404, public_message)
-
-		format = Resolver._format_from_ident(ident)
-		logger.debug('src format %s' % (format,))
-
-		return (fp, format)
-
-class SourceImageCachingResolver(Resolver):
-	from shutil import copy
-	from os import makedirs
-	from os.path import dirname
+    def resolve(self, ident):
+        """
+        Given the identifier of an image, get the path (fp) and format (one of. 
+        'jpg', 'tif', or 'jp2'). This will likely need to be reimplemented for
+        environments and can be as smart or dumb as you want.
+        
+        Args:
+            ident (str):
+                The identifier for the image.
+        Returns:
+            (str, str): (fp, format)
+        Raises:
+            ResolverException when something goes wrong...
+        """
+        e = self.__class__.__name__
+        raise NotImplementedError('resolve() not implemented for %s' % (cn,))
 
 
-	def __init__(self, config, disk_cache_root):
-		super(Resolver, self).__init__(config)
-		self.disk_cache_root = disk_cache_root
+class SimpleFSResolver(_AbstractResolver):
 
-	def resolve(self, ident):
-		ident = unquote(ident)
-		local_fp = join(self.disk_cache_root, ident)
+    def __init__(self, config):
+        super(SimpleFSResolver, self).__init__(config)
+        self.cache_root = self.config['src_img_root']
 
-		if exists(local_fp):
-			format = SourceImageCachingResolver._format_from_ident(ident)
-			logger.debug('src image from local disk: %s' % (local_fp,))
-			return (local_fp, format)
-		else:
-			fp = join(self.cache_root, ident)
-			logger.debug('src image: %s' % (fp,))
-			if not exists(fp):
-				public_message = 'Source image not found for identifier: %s.' % (ident,)
-				log_message = 'Source image not found at %s for identifier: %s.' % (fp,ident)
-				logger.warn(log_message)
-				raise ResolverException(400, public_message)
+    def is_resolvable(self, ident):
+        ident = unquote(ident)
+        fp = join(self.cache_root, ident)
+        return exists(fp)
 
-			makedirs(dirname(local_fp))
-			copy(fp, local_fp)
-			logger.info("Copied %s to %s" % (fp, local_fp))
+    @staticmethod
+    def _format_from_ident(ident):
+        return ident.split('.')[-1]
 
-			format = SourceImageCachingResolver._format_from_ident(ident)
-			logger.debug('src format %s' % (format,))
+    def resolve(self, ident):
+        # For this dumb version a constant path is prepended to the identfier 
+        # supplied to get the path It assumes this 'identifier' ends with a file 
+        # extension from which the format is then derived.
+        ident = unquote(ident)
+        fp = join(self.cache_root, ident)
+        logger.debug('src image: %s' % (fp,))
 
-			return (local_fp, format)
+        if not exists(fp):
+            public_message = 'Source image not found for identifier: %s.' % (ident,)
+            log_message = 'Source image not found at %s for identifier: %s.' % (fp,ident)
+            logger.warn(log_message)
+            raise ResolverException(404, public_message)
+
+        format = SimpleFSResolver._format_from_ident(ident)
+        logger.debug('src format %s' % (format,))
+
+        return (fp, format)
+
+class SourceImageCachingResolver(SimpleFSResolver):
+
+    def __init__(self, config):
+        super(SourceImageCachingResolver, self).__init__(config)
+
+    def resolve(self, ident):
+        ident = unquote(ident)
+        local_fp = join(self.disk_cache_root, ident)
+
+        if exists(local_fp):
+            format = SourceImageCachingResolver._format_from_ident(ident)
+            logger.debug('src image from local disk: %s' % (local_fp,))
+            return (local_fp, format)
+        else:
+            fp = join(self.cache_root, ident)
+            logger.debug('src image: %s' % (fp,))
+            if not exists(fp):
+                public_message = 'Source image not found for identifier: %s.' % (ident,)
+                log_message = 'Source image not found at %s for identifier: %s.' % (fp,ident)
+                logger.warn(log_message)
+                raise ResolverException(400, public_message)
+
+            makedirs(dirname(local_fp))
+            copy(fp, local_fp)
+            logger.info("Copied %s to %s" % (fp, local_fp))
+
+            format = SimpleFSResolver._format_from_ident(ident)
+            logger.debug('src format %s' % (format,))
+
+            return (local_fp, format)
 
 
 

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -76,7 +76,7 @@ def create_app(debug=False):
 
         logger.debug('Running in debug mode.')
 
-        # override some stuff to look at relative directories.
+        # override some stuff to look at relative or tmp directories.
         config['loris.Loris']['www_dp'] = path.join(project_dp, 'www')
         config['loris.Loris']['tmp_dp'] = '/tmp/loris/tmp'
         config['loris.Loris']['enable_caching'] = True

--- a/tests/resolver_t.py
+++ b/tests/resolver_t.py
@@ -1,7 +1,12 @@
 #-*- coding: utf-8 -*-
 
+from loris.resolver import SourceImageCachingResolver
+from os.path import dirname
+from os.path import isfile
+from os.path import join
+from os.path import realpath
+from urllib import unquote
 import loris_t
-from os import path
 
 
 """
@@ -13,19 +18,41 @@ $ python -m unittest tests.resolver_t
 from the `/loris` (not `/loris/loris`) directory.
 """
 
-class Test_A_Resolver(loris_t.LorisTest):
-	'Test that the ID resolver works'
+class Test_SimpleFSResolver(loris_t.LorisTest):
+	'Test that the default resolver works'
 
 	def test_configured_resolver(self):
 		expected_path = self.test_jp2_color_fp
 		resolved_path, fmt = self.app.resolver.resolve(self.test_jp2_color_id)
 		self.assertEqual(expected_path, resolved_path)
 		self.assertEqual(fmt, 'jp2')
-		self.assertTrue(path.isfile(resolved_path))
+		self.assertTrue(isfile(resolved_path))
+
+class Test_SourceImageCachingResolver(loris_t.LorisTest):
+	'Test that the SourceImageCachingResolver resolver works'
+
+	def test_source_image_caching_resolver(self):
+		# First we need to change the resolver on the test instance of the 
+		# application (overrides the config to use SimpleFSResolver)
+		config = {
+			'source_root' : join(dirname(realpath(__file__)), 'img'), 
+			'cache_root' : self.app.img_cache.cache_root
+		}
+		self.app.resolver = SourceImageCachingResolver(config)
+
+		# Now...
+		ident = self.test_jp2_color_id
+		resolved_path, fmt = self.app.resolver.resolve(ident)
+		expected_path = join(self.app.img_cache.cache_root, unquote(ident))
+
+		self.assertEqual(expected_path, resolved_path)
+		self.assertEqual(fmt, 'jp2')
+		self.assertTrue(isfile(resolved_path))
 
 def suite():
 	import unittest
 	test_suites = []
-	test_suites.append(unittest.makeSuite(Test_A_Resolver, 'test'))
+	test_suites.append(unittest.makeSuite(Test_SimpleFSResolver, 'test'))
+	test_suites.append(unittest.makeSuite(Test_SourceImageCachingResolver, 'test'))
 	test_suite = unittest.TestSuite(test_suites)
 	return test_suite


### PR DESCRIPTION
Closes #62, and should help @lfarrell get on with implementing his own resolver. There are now two resolver examples in [resolver.py](https://github.com/pulibrary/loris/blob/development/loris/resolver.py).
