### PR TITLE
Made number of threads for kdu_expand configurable. Closes #57.

### DIFF
--- a/etc/loris.conf
+++ b/etc/loris.conf
@@ -58,6 +58,7 @@ target_formats=jpg,png,gif
 tmp_dp=/tmp/loris/tmp/jp2
 kdu_expand=/usr/local/bin/kdu_expand
 kdu_libs=/usr/local/lib
+num_threads=4
 mkfifo=/usr/bin/mkfifo
 map_profile_to_srgb=1
 srgb_profile_fp=/usr/share/color/icc/colord/sRGB.icc

--- a/loris/transforms.py
+++ b/loris/transforms.py
@@ -171,6 +171,7 @@ class JP2_Transformer(_AbstractTransformer):
 		self.tmp_dp = config['tmp_dp']
 		self.kdu_expand = config['kdu_expand']
 		self.mkfifo = config['mkfifo']
+		self.num_threads = config['num_threads']
 		self.map_profile_to_srgb = bool(config['map_profile_to_srgb'])
 		self.env = {
 			'LD_LIBRARY_PATH' : config['kdu_libs'], 
@@ -291,7 +292,7 @@ class JP2_Transformer(_AbstractTransformer):
 
 		# kdu command
 		q = '-quiet'
-		t = '-num_threads 8'
+		t = '-num_threads %s' % (self.num_threads)
 		i = '-i %s' % (src_fp,)
 		o = '-o %s' % (fifo_fp,)
 


### PR DESCRIPTION
Ran all tests with a variety of values--4 threads seems to be the sweet spot. On my machine even 5 or 3 add almost a second to the time it takes to execute the entire test suite.
