### PR TITLE
Add option to make identifier/ redirect to info.json

### DIFF
--- a/etc/loris2.conf
+++ b/etc/loris2.conf
@@ -32,6 +32,9 @@ run_as_group = 'loris'
 default_format = 'jpg'
 enable_caching = True
 redirect_canonical_image_request = False
+# Should 'identifier/' redirect to info.json? This is generally OK, unless your 
+# identifier could end with a forward slashe.
+redirect_id_slash_to_info = True 
 
 [logging]
 log_to = 'file'    # 'console'|'file'

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -226,6 +226,7 @@ class Loris(object):
         self.www_dp = _loris_config['www_dp']
         self.enable_caching = _loris_config['enable_caching']
         self.redirect_canonical_image_request = _loris_config['redirect_canonical_image_request']
+        self.redirect_id_slash_to_info = _loris_config['redirect_id_slash_to_info']
         self.default_format = _loris_config['default_format']
 
         # TODO: make sure loading  transformers makes sense. What am I doing
@@ -270,7 +271,7 @@ class Loris(object):
         return response(environ, start_response)
 
     def route(self, request):
-        base_uri, ident, params = Loris._dissect_uri(request)
+        base_uri, ident, params = self._dissect_uri(request)
         # index.txt
         if ident == '': 
             return self.get_index(request)
@@ -536,8 +537,7 @@ class Loris(object):
         _id = uuid.uuid1().hex
         return path.sep.join([_id[i:i+2] for i in range(0, len(_id), 2)])
 
-    @staticmethod
-    def _dissect_uri(r):
+    def _dissect_uri(self, r):
         ident = None
         params = None
         # info
@@ -552,6 +552,10 @@ class Loris(object):
         # bare
         else:
             ident = r.path[1:] # no leading slash
+            if self.redirect_id_slash_to_info and ident.endswith('/'): 
+                ident = ident[:-1]
+                # ... you're in trouble if your identifier has a trailing slash
+
             params = ''
         ident = quote_plus(ident)
 

--- a/tests/webapp_t.py
+++ b/tests/webapp_t.py
@@ -32,7 +32,7 @@ class Test_E_WebappUnit(loris_t.LorisTest):
         env = builder.get_environ()
         req = Request(env)
 
-        base_uri, ident, params = webapp.Loris._dissect_uri(req)
+        base_uri, ident, params = self.app._dissect_uri(req)
         expected = '/'.join((self.URI_BASE, self.test_jp2_color_id))
         self.assertEqual(base_uri, expected)
 
@@ -43,7 +43,7 @@ class Test_E_WebappUnit(loris_t.LorisTest):
         env = builder.get_environ()
         req = Request(env)
 
-        base_uri, ident, params = webapp.Loris._dissect_uri(req)
+        base_uri, ident, params = self.app._dissect_uri(req)
         expected = '/'.join((self.URI_BASE, self.test_jp2_color_id))
         self.assertEqual(base_uri, expected)
 
@@ -53,6 +53,15 @@ class Test_F_WebappFunctional(loris_t.LorisTest):
     def test_bare_identifier_request_303(self):
         resp = self.client.get('/%s' % (self.test_jp2_color_id,))
         self.assertEqual(resp.status_code, 303)
+
+    def test_bare_identifier_request_with_trailing_slash_303(self):
+        resp = self.client.get('/%s/' % (self.test_jp2_color_id,))
+        self.assertEqual(resp.status_code, 303)
+
+    def test_bare_identifier_with_trailing_slash_404s_with_redir_off(self):
+        self.app.redirect_id_slash_to_info = False
+        resp = self.client.get('/%s/' % (self.test_jp2_color_id,))
+        self.assertEqual(resp.status_code, 404)
 
     def test_access_control_allow_origin_on_info_requests(self):
         uri = '/%s/info.json' % (self.test_jp2_color_id,)


### PR DESCRIPTION
This is in addition to identifier w/o trailing '/'. Closes #94.
