### PR TITLE
Fix nginx proxy header

### DIFF
--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -39,7 +39,7 @@ http {
         location /iiif/ {        
             proxy_pass         http://app_servers;
             proxy_redirect     off;
-            proxy_set_header   Host $host;
+            proxy_set_header   Host $http_host;
             proxy_set_header   X-Real-IP $remote_addr;
             proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header   X-Forwarded-Host $server_name;


### PR DESCRIPTION
Passes full url (including port) to upstream servers. Fixes #131
