### PR TITLE
Initial stab at SimpleHTTPResolver Functionality

### DIFF
--- a/bin/loris-http_cache_clean.sh
+++ b/bin/loris-http_cache_clean.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+#
+# cache_clean.sh
+# Cron script for maintaining the loris cache size.
+#
+# CAUTION - This script deletes files. Be careful where you point it!
+#
+LOG="/var/log/loris/cache_clean.log"
+
+# Check that the cache directories...
+IMG_CACHE_ROOT_DIR="/usr/local/share/images/loris"
+IMG_CACHE_DP_DIR="/var/cache/loris/img"
+IMG_CACHE_LINKS_DIR="/var/cache/loris/links"
+
+# ...is below a certain size...
+# REDUCE_TO=1048576 #1 gb
+# REDUCE_TO=1073741824 # 1 TB
+# REDUCE_TO=2147483648 # 2 TB
+REDUCE_TO=20971520 #20 gb
+
+# ...and when it is larger, start deleting files accessed more than a certain 
+# number of days ago until the cache is smaller than the configured size.
+
+# Note the name of the variable __REDUCE_TO__: this should not be the total 
+# amount of space you can afford for the cache, but instead the total space 
+# you can afford MINUS the amount you expect the cache to grow in between 
+# executions of this script.
+
+current_usage_cache_root () {
+	du -sk IMG_CACHE_ROOT_DIR | cut -f 1
+}
+
+current_usage_cache_dp () {
+	du -sk IMG_CACHE_DP_DIR | cut -f 1
+}
+
+delete_total=0
+max_age=60 # days
+usage=$(current_usage_cache_dp)+$(current_usage_cache_root)
+start_size=$usage
+run=1
+while [ $usage -gt $REDUCE_TO ] && [ $max_age -ge -1 ]; do
+	run=0
+
+	# files. loop (instead of -delete) so that we can keep count
+	for f in $(find $IMG_CACHE_ROOT_DIR -name loris_cache.* -type f -atime +$max_age); do
+		rm $f
+		let delete_total+=1
+	done
+
+	# files. loop (instead of -delete) so that we can keep count
+	for f in $(find $IMG_CACHE_DP_DIR -type f -atime +$max_age); do
+		rm $f
+		let delete_total+=1
+	done
+
+    # empty directories
+	find $IMG_CACHE_ROOT_DIR -mindepth 1 -type d -empty -delete
+	find $IMG_CACHE_DP_DIR -mindepth 1 -type d -empty -delete
+
+	# broken symlinks
+	find -L $IMG_CACHE_LINKS_DIR -type l -delete
+	find $IMG_CACHE_LINKS_DIR -mindepth 1 -type d -empty -delete
+
+	let max_age-=1
+	usage=$(current_usage_cache_dp)+$(current_usage_cache_root)
+done
+
+echo -ne "$(date +[%c]) " >> $LOG
+if [ $run == 0 ]; then
+	echo -ne "Deleted $delete_count files to " >> $LOG
+	echo "get cache from $start_size kb to $usage kb." >> $LOG
+else
+	echo "Cache at $usage kb (no deletes required)." >> $LOG
+fi
+
+
+
+

--- a/etc/loris2.conf
+++ b/etc/loris2.conf
@@ -2,27 +2,27 @@
 #
 # This file is parsed by the ConfigObj library:
 #
-# <http://www.voidspace.org.uk/python/configobj.html> 
+# <http://www.voidspace.org.uk/python/configobj.html>
 #
-# ConfigObj uses an ini-like syntax with a few important changes and extensions, 
+# ConfigObj uses an ini-like syntax with a few important changes and extensions,
 # which are explained here:
 #
 # <http://www.voidspace.org.uk/python/configobj.html#config-files>
 #
 # Note that 'unrepr' mode is used, which means that values are parsed as Python
-# datatypes, e.g. strings are in quotes, integers are not, True is used for the 
-# boolean value TRUE, False for the boolean value FALSE, and lists are in [] 
+# datatypes, e.g. strings are in quotes, integers are not, True is used for the
+# boolean value TRUE, False for the boolean value FALSE, and lists are in []
 # with commas (',') as the separators.
 #
 # <http://www.voidspace.org.uk/python/configobj.html#unrepr-mode>
 #
 # String interpolation is disabled.
 #
-# IMPORTANT: Be sure that Loris (i.e. the user running the application) has at 
-# least the permissions in the comment at the end of each line for the 
-# directories and files you configure here. It's best if directories already 
+# IMPORTANT: Be sure that Loris (i.e. the user running the application) has at
+# least the permissions in the comment at the end of each line for the
+# directories and files you configure here. It's best if directories already
 # exist.
-# 
+#
 
 [loris.Loris]
 tmp_dp = '/tmp/loris/tmp' # r--
@@ -46,6 +46,16 @@ format = '%(asctime)s (%(name)s) [%(levelname)s]: %(message)s'
 [resolver]
 impl = 'SimpleFSResolver'
 src_img_root = '/usr/local/share/images' # r--
+
+#Example of one version of SimpleHTTResolver config
+
+#[resolver]
+#impl = 'SimpleHTTPResolver'
+#source_prefix='https://<server>/fedora/objects/'
+#source_suffix='/datastreams/accessMaster/content'
+#cache_root='/usr/local/share/images/loris'
+#user='<if needed else remove this line>'
+#pw='<if needed else remove this line>'
 
 [img.ImageCache]
 cache_dp = '/var/cache/loris/img' # rwx

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -4,13 +4,17 @@
 ================================================
 """
 from logging import getLogger
-import loris_exception
+from loris_exception import ResolverException
 from os.path import join, exists, isfile
-from urllib import unquote
-from shutil import copy
 from os import makedirs
 from os.path import dirname
-from loris_exception import ResolverException
+from shutil import copy
+from urllib import unquote, quote_plus
+
+import constants
+import hashlib
+import glob
+import requests
 
 logger = getLogger(__name__)
 
@@ -30,7 +34,7 @@ class _AbstractResolver(object):
         Returns:
             bool
         """
-        e = self.__class__.__name__
+        cn = self.__class__.__name__
         raise NotImplementedError('is_resolvable() not implemented for %s' % (cn,))
 
     def resolve(self, ident):
@@ -47,7 +51,7 @@ class _AbstractResolver(object):
         Raises:
             ResolverException when something goes wrong...
         """
-        e = self.__class__.__name__
+        cn = self.__class__.__name__
         raise NotImplementedError('resolve() not implemented for %s' % (cn,))
 
 
@@ -85,6 +89,208 @@ class SimpleFSResolver(_AbstractResolver):
 
         return (fp, format)
 
+class SimpleHTTPResolver(_AbstractResolver):
+    '''
+    Example resolver that one might use if image files were coming from
+    an http image store (like Fedora Commons). The first call to `resolve()`
+    copies the source image into a local cache; subsequent calls use local
+    copy from the cache.
+
+    The config dictionary MUST contain
+     * `cache_root`, which is the absolute path to the directory where source images
+        should be cached.
+
+    The config dictionary MAY contain
+     * `source_prefix`, the url up to the identifier.
+     * `source_suffix`, the url after the identifier (if applicable).
+     * `default_format`, the format of images (will use content-type of response if not specified).
+     * `head_resolvable` with value True, whether to make HEAD requests to verify object existence (don't set if using
+        Fedora Commons prior to 3.8).
+     * `uri_resolvable` with value True, allows one to use full uri's to resolve to an image.
+     * `user`, the username to make the HTTP request as.
+     * `pw`, the password to make the HTTP request as.
+    '''
+    def __init__(self, config):
+        super(SimpleHTTPResolver, self).__init__(config)
+
+        self.source_prefix = self.config.get('source_prefix', '')
+
+        self.source_suffix = self.config.get('source_suffix', '')
+
+        self.default_format = self.config.get('default_format', None)
+
+        self.head_resolvable = self.config.get('head_resolvable', False)
+
+        self.uri_resolvable = self.config.get('uri_resolvable', False)
+
+        self.user = self.config.get('user', None)
+
+        self.pw = self.config.get('pw', None)
+
+        if 'cache_root' in self.config:
+            self.cache_root = self.config['cache_root']
+        else:
+            message = 'Server Side Error: Configuration incomplete and cannot resolve. Missing setting for cache_root.'
+            logger.error(message)
+            raise ResolverException(500, message)
+
+        if not self.uri_resolvable and self.source_prefix == '':
+            message = 'Server Side Error: Configuration incomplete and cannot resolve. Must either set uri_resolvable' \
+                      ' or source_prefix settings.'
+            logger.error(message)
+            raise ResolverException(500, message)
+
+    def is_resolvable(self, ident):
+        ident = unquote(ident)
+        fp = join(self.cache_root, SimpleHTTPResolver._cache_subroot(ident))
+        if exists(fp):
+            return True
+        else:
+            fp = SimpleHTTPResolver._web_request_url(ident, self.uri_resolvable, self.source_prefix, self.source_suffix)
+
+            if self.head_resolvable:
+                try:
+                    if self.user is not None and self.pw is not None:
+                        response = requests.head(fp, auth=(self.user, self.pw))
+                    else:
+                        response = requests.head(fp)
+                except requests.exceptions.MissingSchema:
+                    return False
+            else:
+                try:
+                    if self.user is not None and self.pw is not None:
+                        response = requests.get(fp, stream = True, auth=(self.user, self.pw))
+                    else:
+                        response = requests.get(fp, stream = True)
+                except requests.exceptions.MissingSchema:
+                    return False
+
+            if response.status_code is 200:
+                return True
+
+        return False
+
+    def format_from_ident(self, ident, potential_format):
+        if self.default_format is not None:
+            return self.default_format
+        elif potential_format is not None:
+            return potential_format
+        elif ident.rfind('.') != -1 and (len(ident) - ident.rfind('.') <= 5):
+            return ident.split('.')[-1]
+        else:
+            public_message = 'Format could not be determined for: %s.' % (ident,)
+            log_message = 'Format could not be determined for: %s.' % (ident)
+            logger.warn(log_message)
+            raise ResolverException(404, public_message)
+
+    @staticmethod
+    def _web_request_url(ident, is_uri_resolvable, prefix, suffix):
+        if (ident[0:6] == 'http:/' or ident[0:7] == 'https:/') and is_uri_resolvable:
+            #ident is http request with no prefix or suffix specified
+            #For some reason, identifier is http:/<url> or https:/<url>? Hack to correct.
+            return ident[0:ident.find('/')] + '/' + ident[ident.find('/'):len(ident)]
+        else:
+            return prefix + ident + suffix
+
+    #Get a subdirectory structure for the cache_subroot through hashing.
+    @staticmethod
+    def _cache_subroot(ident):
+        cache_subroot = ''
+
+        #Split out potential pidspaces... Fedora Commons most likely use case.
+        if ident[0:6] != 'http:/' and ident[0:7] != 'https:/' and len(ident.split(':')) > 1:
+            for split_ident in ident.split(':')[0:-1]:
+                cache_subroot = join(cache_subroot, split_ident)
+        elif ident[0:6] == 'http:/' or ident[0:7] == 'https:/':
+            cache_subroot = 'http'
+
+        cache_subroot = join(cache_subroot, SimpleHTTPResolver._ident_file_structure(ident))
+
+        return cache_subroot
+
+    #Get the directory structure of the identifier itself
+    @staticmethod
+    def _ident_file_structure(ident):
+        file_structure = ''
+        ident_hash = hashlib.md5(quote_plus(ident)).hexdigest()
+        #First level 2 digit directory then do three digits...
+        file_structure_list = [ident_hash[0:2]] + [ident_hash[i:i+3] for i in range(2, len(ident_hash), 3)]
+
+        for piece in file_structure_list:
+            file_structure = join(file_structure, piece)
+
+        return file_structure
+
+    def resolve(self, ident):
+        ident = unquote(ident)
+
+        local_fp = join(self.cache_root, SimpleHTTPResolver._cache_subroot(ident))
+        local_fp = join(local_fp)
+
+        if exists(local_fp):
+            cached_object = glob.glob(join(local_fp, 'loris_cache.*'))
+
+            if len(cached_object) > 0:
+                cached_object = cached_object[0]
+            else:
+                public_message = 'Cached image not found for identifier: %s.' % (ident)
+                log_message = 'Cached image not found for identifier: %s. Empty directory where image expected?' % (ident)
+                logger.warn(log_message)
+                raise ResolverException(404, public_message)
+
+            format = self.format_from_ident(cached_object,None)
+            logger.debug('src image from local disk: %s' % (cached_object,))
+            return (cached_object, format)
+        else:
+            fp = SimpleHTTPResolver._web_request_url(ident, self.uri_resolvable, self.source_prefix, self.source_suffix)
+
+            logger.debug('src image: %s' % (fp,))
+
+            try:
+                if self.user is not None and self.pw is not None:
+                    response = requests.get(fp, stream = True, auth=(self.user, self.pw))
+                else:
+                    response = requests.get(fp, stream = True)
+            except requests.exceptions.MissingSchema:
+                public_message = 'Bad URL request made for identifier: %s.' % (ident,)
+                log_message = 'Bad URL request at %s for identifier: %s.' % (fp,ident)
+                logger.warn(log_message)
+                raise ResolverException(404, public_message)
+
+            if response.status_code != 200:
+                public_message = 'Source image not found for identifier: %s. Status code returned: %s' % (ident,response.status_code)
+                log_message = 'Source image not found at %s for identifier: %s. Status code returned: %s' % (fp,ident,response.status_code)
+                logger.warn(log_message)
+                raise ResolverException(404, public_message)
+
+            if 'content-type' in response.headers:
+                try:
+                    format = self.format_from_ident(ident, constants.FORMATS_BY_MEDIA_TYPE[response.headers['content-type']])
+                except KeyError:
+                    logger.warn('Your server may be responding with incorrect content-types. Reported %s for ident %s.'
+                                % (response.headers['content-type'],ident))
+                    #Attempt without the content-type
+                    format = self.format_from_ident(ident, None)
+            else:
+                format = self.format_from_ident(ident, None)
+
+            logger.debug('src format %s' % (format,))
+
+            local_fp = join(local_fp, "loris_cache." + format)
+
+            try:
+                makedirs(dirname(local_fp))
+            except:
+                logger.debug("Directory already existed... possible problem if not a different format")
+
+            with open(local_fp, 'wb') as fd:
+                for chunk in response.iter_content(2048):
+                    fd.write(chunk)
+
+            logger.info("Copied %s to %s" % (fp, local_fp))
+
+            return (local_fp, format)
+
 class SourceImageCachingResolver(_AbstractResolver):
     '''
     Example resolver that one might use if image files were coming from
@@ -103,7 +309,7 @@ class SourceImageCachingResolver(_AbstractResolver):
 
     def is_resolvable(self, ident):
         ident = unquote(ident)
-        fp = join(self.cache_root, ident)
+        fp = join(self.source_root, ident)
         return exists(fp)
 
     @staticmethod

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -81,7 +81,7 @@ def create_app(debug=False, debug_jp2_transformer='kdu'):
         config['img.ImageCache']['cache_links'] = '/tmp/loris/cache/links'
         config['img.ImageCache']['cache_dp'] = '/tmp/loris/cache/img'
         config['img_info.InfoCache']['cache_dp'] = '/tmp/loris/cache/info'
-        config['resolver']['impl'] = 'SimpleFSResolver' 
+        config['resolver']['impl'] = 'SimpleFSResolver'
         config['resolver']['src_img_root'] = path.join(project_dp,'tests','img')
         
         if debug_jp2_transformer == 'opj':
@@ -288,7 +288,6 @@ class Loris(object):
         if not self.resolver.is_resolvable(ident):
             msg = "could not resolve identifier: %s " % (ident)
             return NotFoundResponse(msg)
-
         elif params == '' and request_type == 'info':
             r = LorisResponse()
             r.headers['Location'] = '%s/info.json' % (base_uri,)
@@ -346,6 +345,7 @@ class Loris(object):
 
         # Otherwise, does the path end with info.json?
         elif r.path.endswith('info.json'):
+        #if r.path.endswith('info.json'):
             ident = '/'.join(r.path[1:].split('/')[:-1])
             params = 'info.json'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ werkzeug >= 0.8.3
 pillow >= 2.4.0
 configobj >= 4.7.2,<=5.0.0
 ordereddict
+requests
+mock
+responses

--- a/tests/resolver_t.py
+++ b/tests/resolver_t.py
@@ -1,12 +1,15 @@
 #-*- coding: utf-8 -*-
-
+from loris.loris_exception import ResolverException
+from loris.resolver import SimpleHTTPResolver
 from loris.resolver import SourceImageCachingResolver
 from os.path import dirname
 from os.path import isfile
 from os.path import join
 from os.path import realpath
-from urllib import unquote
+from urllib import unquote, quote_plus
+
 import loris_t
+import responses
 
 
 """
@@ -49,10 +52,187 @@ class Test_SourceImageCachingResolver(loris_t.LorisTest):
 		self.assertEqual(fmt, 'jp2')
 		self.assertTrue(isfile(resolved_path))
 
+class Test_SimpleHTTPResolver(loris_t.LorisTest):
+	'Test that the SourceImageCachingResolver resolver works'
+
+	@responses.activate
+	def test_simple_http_resolver(self):
+
+		# Mock out some urls for testing....
+		responses.add(responses.GET, 'http://sample.sample/0001',
+                      body='II*\x00\x0c\x00\x00\x00\x80\x00  \x0e\x00\x00\x01\x03\x00\x01\x00\x00\x00\x01\x00\x00\x00\x01\x01\x03\x00\x01\x00\x00\x00\x01\x00\x00\x00\x02\x01\x03\x00\x01\x00\x00\x00\x08\x00\x00\x00\x03\x01\x03\x00\x01\x00\x00\x00\x05\x00\x00\x00\x06\x01\x03\x00\x01\x00\x00\x00\x03\x00\x00\x00\x11\x01\x04\x00\x01\x00\x00\x00\x08\x00\x00\x00\x15\x01\x03\x00\x01\x00\x00\x00\x01\x00\x00\x00\x16\x01\x03\x00\x01\x00\x00\x00\x08\x00\x00\x00\x17\x01\x04\x00\x01\x00\x00\x00\x04\x00\x00\x00\x1a\x01\x05\x00\x01\x00\x00\x00\xba\x00\x00\x00\x1b\x01\x05\x00\x01\x00\x00\x00\xc2\x00\x00\x00\x1c\x01\x03\x00\x01\x00\x00\x00\x01\x00\x00\x00(\x01\x03\x00\x01\x00\x00\x00\x02\x00\x00\x00@\x01\x03\x00\x00\x03\x00\x00\xca\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00H\x00\x00\x00\x01\x00\x00\x00H\x00\x00\x00\x01\x00\x00\x00\xff`\xe6q\x19\x08\x00\x00\x80\t\x00\x00\x80\n\x00\x00\x80\x0b\x00\x00\x80\x0c\x00\x00\x80\r',
+                      status=200,
+                      content_type='image/tiff')
+
+		responses.add(responses.GET, 'http://sample.sample/0002',
+                      body='II*\x00\x0c\x00\x00\x00\x80\x00  \x0e\x00\x00\x01\x03\x00\x01\x00\x00\x00\x01\x00\x00\x00\x01\x01\x03\x00\x01\x00\x00\x00\x01\x00\x00\x00\x02\x01\x03\x00\x01\x00\x00\x00\x08\x00\x00\x00\x03\x01\x03\x00\x01\x00\x00\x00\x05\x00\x00\x00\x06\x01\x03\x00\x01\x00\x00\x00\x03\x00\x00\x00\x11\x01\x04\x00\x01\x00\x00\x00\x08\x00\x00\x00\x15\x01\x03\x00\x01\x00\x00\x00\x01\x00\x00\x00\x16\x01\x03\x00\x01\x00\x00\x00\x08\x00\x00\x00\x17\x01\x04\x00\x01\x00\x00\x00\x04\x00\x00\x00\x1a\x01\x05\x00\x01\x00\x00\x00\xba\x00\x00\x00\x1b\x01\x05\x00\x01\x00\x00\x00\xc2\x00\x00\x00\x1c\x01\x03\x00\x01\x00\x00\x00\x01\x00\x00\x00(\x01\x03\x00\x01\x00\x00\x00\x02\x00\x00\x00@\x01\x03\x00\x00\x03\x00\x00\xca\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00H\x00\x00\x00\x01\x00\x00\x00H\x00\x00\x00\x01\x00\x00\x00\xff`\xe6q\x19\x08\x00\x00\x80\t\x00\x00\x80\n\x00\x00\x80\x0b\x00\x00\x80\x0c\x00\x00\x80\r',
+                      status=200)
+
+		responses.add(responses.GET, 'http://sample.sample/0003',
+                      body='II*\x00\x0c\x00\x00\x00\x80\x00  \x0e\x00\x00\x01\x03\x00\x01\x00\x00\x00\x01\x00\x00\x00\x01\x01\x03\x00\x01\x00\x00\x00\x01\x00\x00\x00\x02\x01\x03\x00\x01\x00\x00\x00\x08\x00\x00\x00\x03\x01\x03\x00\x01\x00\x00\x00\x05\x00\x00\x00\x06\x01\x03\x00\x01\x00\x00\x00\x03\x00\x00\x00\x11\x01\x04\x00\x01\x00\x00\x00\x08\x00\x00\x00\x15\x01\x03\x00\x01\x00\x00\x00\x01\x00\x00\x00\x16\x01\x03\x00\x01\x00\x00\x00\x08\x00\x00\x00\x17\x01\x04\x00\x01\x00\x00\x00\x04\x00\x00\x00\x1a\x01\x05\x00\x01\x00\x00\x00\xba\x00\x00\x00\x1b\x01\x05\x00\x01\x00\x00\x00\xc2\x00\x00\x00\x1c\x01\x03\x00\x01\x00\x00\x00\x01\x00\x00\x00(\x01\x03\x00\x01\x00\x00\x00\x02\x00\x00\x00@\x01\x03\x00\x00\x03\x00\x00\xca\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00H\x00\x00\x00\x01\x00\x00\x00H\x00\x00\x00\x01\x00\x00\x00\xff`\xe6q\x19\x08\x00\x00\x80\t\x00\x00\x80\n\x00\x00\x80\x0b\x00\x00\x80\x0c\x00\x00\x80\r',
+                      status=200,
+                      content_type='image/invalidformat')
+
+		responses.add(responses.GET, 'http://sample.sample/DOESNOTEXIST',
+                      body='Does Not Exist',
+                      status=404,
+                      content_type='application/html')
+
+
+		# First we test with no config...
+		config = {
+		}
+		self.assertRaises(ResolverException, lambda: SimpleHTTPResolver(config))
+
+        # Then we test missing source_prefix and uri_resolvable
+		config = {
+			'cache_root' : self.app.img_cache.cache_root
+		}
+		self.assertRaises(ResolverException, lambda: SimpleHTTPResolver(config))
+
+		# Then we test with the full config...
+        #TODO: More granular testing of these settings...
+		config = {
+			'cache_root' : self.app.img_cache.cache_root,
+			'source_prefix' : 'http://www.mysite/',
+			'source_suffix' : '/accessMaster',
+			'default_format' : 'jp2',
+			'head_resolvable' : True,
+			'uri_resolvable' : True,
+			'user' : 'TestUser',
+			'pw' : 'TestPW',
+		}
+
+		self.app.resolver = SimpleHTTPResolver(config)
+		self.assertEqual(self.app.resolver.cache_root, self.app.img_cache.cache_root)
+		self.assertEqual(self.app.resolver.source_prefix, 'http://www.mysite/')
+		self.assertEqual(self.app.resolver.source_suffix, '/accessMaster')
+		self.assertEqual(self.app.resolver.default_format, 'jp2')
+		self.assertEqual(self.app.resolver.head_resolvable, True)
+		self.assertEqual(self.app.resolver.uri_resolvable, True)
+		self.assertEqual(self.app.resolver.user, 'TestUser')
+		self.assertEqual(self.app.resolver.pw, 'TestPW')
+
+		# Then we test with a barebones default config...
+		config = {
+			'cache_root' : self.app.img_cache.cache_root,
+            'uri_resolvable' : True
+		}
+
+		self.app.resolver = SimpleHTTPResolver(config)
+		self.assertEqual(self.app.resolver.cache_root, self.app.img_cache.cache_root)
+		self.assertEqual(self.app.resolver.source_prefix, '')
+		self.assertEqual(self.app.resolver.source_suffix, '')
+		self.assertEqual(self.app.resolver.default_format, None)
+		self.assertEqual(self.app.resolver.head_resolvable, False)
+		self.assertEqual(self.app.resolver.uri_resolvable, True)
+		self.assertEqual(self.app.resolver.user, None)
+		self.assertEqual(self.app.resolver.pw, None)
+
+        # Finally with the test config for now....
+		config = {
+			'cache_root' : self.app.img_cache.cache_root,
+			'source_prefix' : 'http://sample.sample/',
+			'source_suffix' : '',
+			'head_resolvable' : True,
+			'uri_resolvable' : True
+		}
+
+		self.app.resolver = SimpleHTTPResolver(config)
+		self.assertEqual(self.app.resolver.cache_root, self.app.img_cache.cache_root)
+		self.assertEqual(self.app.resolver.source_prefix, 'http://sample.sample/')
+		self.assertEqual(self.app.resolver.source_suffix, '')
+		self.assertEqual(self.app.resolver.default_format, None)
+		self.assertEqual(self.app.resolver.head_resolvable, True)
+		self.assertEqual(self.app.resolver.uri_resolvable, True)
+
+        #Test with identifier only
+		ident = '0001'
+		resolved_path, fmt = self.app.resolver.resolve(ident)
+		expected_path = join(self.app.img_cache.cache_root, '25')
+		expected_path = join(expected_path, 'bbd')
+		expected_path = join(expected_path, 'cd0')
+		expected_path = join(expected_path, '6c3')
+		expected_path = join(expected_path, '2d4')
+		expected_path = join(expected_path, '77f')
+		expected_path = join(expected_path, '7fa')
+		expected_path = join(expected_path, '1c3')
+		expected_path = join(expected_path, 'e4a')
+		expected_path = join(expected_path, '91b')
+		expected_path = join(expected_path, '032')
+		expected_path = join(expected_path, 'loris_cache.tif')
+
+		self.assertEqual(expected_path, resolved_path)
+		self.assertEqual(fmt, 'tif')
+		self.assertTrue(isfile(resolved_path))
+
+        #Test with a full uri
+        #Note: This seems weird but idents resolve wrong and removes a slash from //
+		ident = quote_plus('http:/sample.sample/0001')
+		resolved_path, fmt = self.app.resolver.resolve(ident)
+		expected_path = join(self.app.img_cache.cache_root, 'http')
+		expected_path = join(expected_path, '9d')
+		expected_path = join(expected_path, '423')
+		expected_path = join(expected_path, 'a05')
+		expected_path = join(expected_path, '863')
+		expected_path = join(expected_path, 'f9f')
+		expected_path = join(expected_path, '89d')
+		expected_path = join(expected_path, '06e')
+		expected_path = join(expected_path, '282')
+		expected_path = join(expected_path, 'e84')
+		expected_path = join(expected_path, '26c')
+		expected_path = join(expected_path, 'b78')
+		expected_path = join(expected_path, 'loris_cache.tif')
+
+		self.assertEqual(expected_path, resolved_path)
+		self.assertEqual(fmt, 'tif')
+		self.assertTrue(isfile(resolved_path))
+
+        #Test with a bad identifier
+		ident = 'DOESNOTEXIST'
+		self.assertRaises(ResolverException, lambda: self.app.resolver.resolve(ident))
+
+        #Test with a bad url
+		ident = quote_plus('http:/sample.sample/DOESNOTEXIST')
+		self.assertRaises(ResolverException, lambda: self.app.resolver.resolve(ident))
+
+        #Test with no content-type or extension or default format
+		ident = '0002'
+		self.assertRaises(ResolverException, lambda: self.app.resolver.resolve(ident))
+
+        #Test with invalid content-type
+		ident = '0003'
+		self.assertRaises(ResolverException, lambda: self.app.resolver.resolve(ident))
+
+        #Tests with a default format...
+		config = {
+			'cache_root' : self.app.img_cache.cache_root,
+			'source_prefix' : 'http://sample.sample/',
+			'source_suffix' : '',
+			'default_format' : 'tif',
+			'head_resolvable' : True,
+			'uri_resolvable' : True
+		}
+		self.app.resolver = SimpleHTTPResolver(config)
+
+		ident = '0002'
+		resolved_path, fmt = self.app.resolver.resolve(ident)
+		self.assertIsNotNone(resolved_path)
+		self.assertEqual(fmt, 'tif')
+		self.assertTrue(isfile(resolved_path))
+
+		ident = '0003'
+		resolved_path, fmt = self.app.resolver.resolve(ident)
+		self.assertIsNotNone(resolved_path)
+		self.assertEqual(fmt, 'tif')
+		self.assertTrue(isfile(resolved_path))
+
+
 def suite():
 	import unittest
 	test_suites = []
 	test_suites.append(unittest.makeSuite(Test_SimpleFSResolver, 'test'))
 	test_suites.append(unittest.makeSuite(Test_SourceImageCachingResolver, 'test'))
+	test_suites.append(unittest.makeSuite(Test_SimpleHTTPResolver, 'test'))
 	test_suite = unittest.TestSuite(test_suites)
 	return test_suite


### PR DESCRIPTION
This pull request adds a SimpleHTTPResolver with various common config
options. These options are as follows:

```
The config dictionary MUST contain
 * `cache_root`, which is the absolute path to the directory where
    source images should be cached.

The config dictionary MAY contain
 * `source_prefix`, the url up to the identifier.
 * `source_suffix`, the url after the identifier (if applicable).
 * `default_format`, the format of images (will use content-type
    of response if not specified).
 * `head_resolvable` with value True, whether to make HEAD requests
    to verify object existence (don't set if using Fedora Commons
    prior to 3.8).
 * `uri_resolvable` with value True, allows one to use full uri's
    to resolve to an image.
 * `user`, the username to make the HTTP request as if needed.
 * `pw`, the password to make the HTTP request as if needed.
```

Additionally, there is a new clean script titled
"loris-http_cache_clean.sh" in the bin directory with more granular
directory options.

Lastly: it now has a dependency of having the requests library installed
(pip install requests).

Known issues:
1. It still does a base bare identifier call that usually will return
   'false' first before trying more common routing cases.
2. The code to determine an identifier will strip out a slash in
   "http://". I currently compensate for this flaw but should bbe fixed
   in webapp.py's _dissect_uri.
3. Unit test coverage is sparse and needs to be expanded for more
   cases. Additionally, things need to be more properly mocked out
   as using a live url for the resolver at the moment.
4. The "links" and "info" directories are a mess regardless of
   resolver due to all entries not being subdivided. Not sure if this
   matters. In addition, it will write ":" if part of the identifier
   (not allowed on some file systems) along with symlinks being
   unsupported in some drive storage cases.
