### PR TITLE
Documentation update for SimpleHTTPResolver

### DIFF
--- a/doc/apache.md
+++ b/doc/apache.md
@@ -28,7 +28,7 @@ ExpiresDefault "access plus 5184000 seconds"
 AllowEncodedSlashes On
 
 WSGIDaemonProcess loris user=loris group=loris processes=10 threads=15 maximum-requests=10000
-WSGIScriptAlias /loris /var/www/loris/loris.wsgi
+WSGIScriptAlias /loris /var/www/loris/loris2.wsgi
 WSGIProcessGroup loris
 ```
 

--- a/doc/cache_maintenance.md
+++ b/doc/cache_maintenance.md
@@ -1,9 +1,17 @@
 Caching
 =======
 
+### `SimpleFSResolver`
+
 There is a Bash script at `bin/loris-cache_clean.sh` that makes heavy use of `find` command line utility to turn the filesystem cache into a simple LRU-style cache. Have a look at it and set the constants near the top; it is intended to be deployed as a cron job.
 
 After you run `setup.py install` this script will be a `/usr/local/bin/loris-cache_clean.sh`.
+
+### `SimpleHTTPResolver`
+
+There is a Bash script at `bin/loris-http_cache_clean.sh` that makes heavy use of `find` command line utility to turn the filesystem cache into a simple LRU-style cache. Have a look at it and set the constants near the top; it is intended to be deployed as a cron job.
+
+After you run `setup.py install` this script will be a `/usr/local/bin/loris-http_cache_clean.sh`.
 
 * * *
 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -46,9 +46,9 @@ The options are fairly self-explanatory; a few pointers
  * `max_backups`. This many previous logs will be kept.
  * `format`. Format of the log entries. See [Python LogRecord attributes](http://docs.python.org/2/library/logging.html#logrecord-attributes) for options.
 
-### `[resolver.Resolver]`
+### `[resolver]`
 
-Any options you add here will be passed through to the resolver you implement. For an explanation of the default resolver, see the [Resolver page](resolver.md).
+Any options you add here will be passed through to the resolver you implement. For an explanation of some of the resolvers, see the [Resolver page](resolver.md).
 
 ### `[transforms.*]`
 

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -52,7 +52,7 @@ In order from least to most tedious:
 
         $ sudo apt-get install libjpeg-turbo8 libjpeg-turbo8-dev libfreetype6 \
         libfreetype6-dev zlib1g-dev liblcms2-2 liblcms2-dev liblcms-utils \
-        libtiff5-dev libwebp-dev
+        libtiff5-dev libwebp-dev python-dev python-setuptools
 
     If you're planning on using OpenJPEG, it should have been installed in step 2 above.
 
@@ -72,6 +72,13 @@ In order from least to most tedious:
         --- WEBP support available
         --- WEBPMUX support available
         [...]
+
+    The following are required python libraries that must currently exist on the system:
+
+        $ sudo pip install configobj
+        $ sudo pip install requests
+        $ sudo pip install mock
+        $ sudo pip install responses
 
     Once you done all of this, go ahead and run the tests. From the `loris` directory (not `loris/loris`) run `./test.py`
 

--- a/doc/resolver.md
+++ b/doc/resolver.md
@@ -1,10 +1,13 @@
 Resolving Identifiers
 =====================
 
-The supplied implementation just unescapes the identifier and tacks a constant path onto the front. e.g. if `ident = 01%2F02%2F0001.jp2` and in the config file:
+### `SimpleFSResolver`
+
+This supplied implementation just unescapes the identifier and tacks a constant path onto the front. e.g. if `ident = 01%2F02%2F0001.jp2` and in the config file:
 
 ```ini
-[resolver.Resolver] 
+[resolver]
+impl = 'SimpleFSResolver'
 src_img_root=/usr/local/share/images
 ```
 
@@ -14,7 +17,68 @@ then `app.resolver.resolve(ident)` will return
 /usr/local/share/images/01/02/0001.jp2
 ```
 
-You'll probably want to do something smarter. See `resolver._AbstractResolver` for details. Note that any properties you add in the `[resolver.Resolver]` section will be in the `self.config` dictionary as long as you subclass `_AbstractResolver`.
+### `SimpleHTTPResolver`
+
+#### Main Configuration
+
+This supplied implementation allows one to resolve identifiers against a HTTP source. This resolver requires a variable of "cache_root" be specified (the location to locally cache retrieved images) and that either "source_prefix" and/or "uri_resolvable" is configured.
+
+A sample config of this resolver might be:
+
+```ini
+[resolver]
+impl = 'SimpleHTTPResolver'
+source_prefix='https://<server>/fedora/objects/'
+source_suffix='/datastreams/accessMaster/content'
+cache_root='/usr/local/share/images/loris'
+user='<if needed else remove this line>'
+pw='<if needed else remove this line>'
+```
+
+Another sample configuration assuming one wishes to use uri's:
+
+```ini
+[resolver]
+impl = 'SimpleHTTPResolver'
+uri_resolvable=True
+cache_root='/usr/local/share/images/loris'
+```
+
+A full configuration sample that shows all the options and their defaults are:
+
+```ini
+[resolver]
+impl = 'SimpleHTTPResolver'
+source_prefix=''
+source_suffix=''
+uri_resolvable=False
+head_resolvable=False #DO set this to true if using Fedora Commons 3.8 or later. Earlier versions have a bug for a head response.
+default_format=None #Set this if your HTTP server doesn't populate content-response. An example value might be "jp2".
+user=None
+pw=None
+cache_root='<must be configured>'
+```
+
+#### Required Other Configurations
+
+Additionally, please note the following must also exist if the "enable_caching" is True and be configured to be owned by the loris user. While the cache_root above with the larger derivatives can be on a NAS, these following must likely be stored on the local server file system to avoid problems (they are somewhat small however):
+
+```ini
+[img.ImageCache]
+cache_dp = '/var/cache/loris/img' # rwx
+cache_links = '/var/cache/loris/links' # rwx
+
+[img_info.InfoCache]
+cache_dp = '/var/cache/loris/info' # rwx
+```
+
+#### Examples in the Wild
+
+[https://www.digitalcommonwealth.org](https://www.digitalcommonwealth.org) - Used for all object images except thumbnails.
+
+### `Creating Your Own`
+
+See `resolver._AbstractResolver` for details. Note that any properties you add in the `[resolver.Resolver]` section will be in the `self.config` dictionary as long as you subclass `_AbstractResolver`.
 
 * * *
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ and then run setup again.
 VERSION = loris.__version__
 
 LORIS_CACHE_CLEAN = os.path.join(BIN_DP, 'loris-cache_clean.sh')
+LORIS_HTTP_CACHE_CLEAN = os.path.join(BIN_DP, 'loris-http_cache_clean.sh')
 
 this_dp = os.path.abspath(os.path.dirname(__file__))
 
@@ -94,7 +95,7 @@ if config['transforms']['jp2']['impl'] == 'KakaduJP2Transformer':
 	JP2_LIBS = os.path.join(LIB_DP, KakaduJP2Transformer.libkdu_name())
 	data_files.append( (LIB_DP, [KakaduJP2Transformer.local_libkdu_path()]) )
 	kdu_expand = KakaduJP2Transformer.local_kdu_expand_path()
-	data_files.append( (BIN_DP, ['bin/loris-cache_clean.sh', 'bin/iiif_img_info', kdu_expand]) )
+	data_files.append( (BIN_DP, ['bin/loris-cache_clean.sh', 'bin/loris-http_cache_clean.sh', 'bin/iiif_img_info', kdu_expand]) )
 
 elif config['transforms']['jp2']['impl'] == 'OPJ_JP2Transformer':
 	from loris.transforms import OPJ_JP2Transformer
@@ -102,7 +103,7 @@ elif config['transforms']['jp2']['impl'] == 'OPJ_JP2Transformer':
 	JP2_LIBS = os.path.join(LIB_DP, OPJ_JP2Transformer.libopenjp2_name())
 	data_files.append( (LIB_DP, [OPJ_JP2Transformer.local_libopenjp2_path()]) )
 	opj_decompress = OPJ_JP2Transformer.local_opj_decompress_path()
-	data_files.append( (BIN_DP, ['bin/loris-cache_clean.sh', 'bin/iiif_img_info', opj_decompress]) )		
+	data_files.append( (BIN_DP, ['bin/loris-cache_clean.sh', 'bin/loris-http_cache_clean.sh', 'bin/iiif_img_info', opj_decompress]) )
 
 def read(fname):
 	return open(os.path.join(os.path.dirname(__file__), fname)).read()
@@ -132,7 +133,7 @@ for fs_node in loris_owned_dirs:
 	os.chown(fs_node, user_id, group_id)
 
 wsgi_script = os.path.join(www_dp, 'loris2.wsgi')
-executables = (LORIS_CACHE_CLEAN, JP2_EXECUTABLE, wsgi_script)
+executables = (LORIS_CACHE_CLEAN, LORIS_HTTP_CACHE_CLEAN, JP2_EXECUTABLE, wsgi_script)
 for ex in executables:
 	os.chmod(ex, 0755)
 	os.chown(ex, user_id, group_id)
@@ -143,6 +144,7 @@ os.chown(index, user_id, group_id)
 
 d = {
 	'cache_clean' : LORIS_CACHE_CLEAN,
+    'cache_http_clean' : LORIS_HTTP_CACHE_CLEAN,
 	'cache_dp' : cache_dp,
 	'cache_links' : cache_links,
 	'config' : ETC_DP,
@@ -160,7 +162,8 @@ todo = '''
 Installation was successful. Here's where things are:
 
  * Loris configuration: %(config)s
- * Cache cleaner cron: %(cache_clean)s
+ * Cache cleaner Simple cron: %(cache_clean)s
+ * Cache cleaner HTTP cron: %(cache_http_clean)s
  * JP2 executable: %(jptoo_exe)s (kdu_expand or opj_decompress)
  * JP2 libraries: %(jptoo_lib)s (libkdu or libopenjp2)
  * Logs: %(logs)s
@@ -179,8 +182,9 @@ In particular:
 	notes about this in doc/dependencies.md.
 
  2. Configure the cron job that manages the cache (bin/loris-cache_clean.sh, 
-	now at %(cache_clean)s). Make sure the constants match 
-	how you have Loris configured, and then set up the cron 
+	now at %(cache_clean)s, or bin/loris-http_cache_clean.sh,
+	now at %(cache_http_clean)s). Make sure the
+	constants match how you have Loris configured, and then set up the cron
 	(e.g. `crontab -e -u %(user_n)s`).
 
  3. Have a look at the WSGI file in %(www_dp)s. It should be fine as-is, but 


### PR DESCRIPTION
Update the documentation for the new resolver. In addition, fix any
errors I am aware of in it. And add functionality to move the Simple
HTTP resolver clean script to where the other clean script is place.

These are the instructions I had to use for it to run under Ubuntu
14.04.

Let me know if you have anything that should be changed. Thanks!
