### PR TITLE
Adds a corrupt jp2 for testing and handles it as best as it can

### DIFF
--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -583,7 +583,9 @@ class Loris(object):
                 # CalledProcessError and IOError typically happen when there are 
                 # permissions problems with one of the files or directories
                 # used by the transformer.
-                msg = '%s \n(This is likely a permissions problem)' % (str(e),)
+                msg = '''%s \n\nThis is likely a permissions problem, though it\'s 
+possible that there was a problem with the source file 
+(%s).''' % (str(e),src_fp)
                 return ServerSideErrorResponse(msg)
 
         r.content_type = constants.FORMATS_BY_EXTENSION[target_fmt]

--- a/misc/jp2_kakadu_pillow.py
+++ b/misc/jp2_kakadu_pillow.py
@@ -10,7 +10,7 @@ import sys
 KDU_EXPAND='/usr/local/bin/kdu_expand'
 LIB_KDU='/usr/local/lib/libkdu_v72R.so'
 TMP='/tmp'
-INPUT_JP2='/home/jstroop/Desktop/nanteuil.jp2'
+INPUT_JP2='/home/jstroop/workspace/loris/tests/img/corrupt.jp2'
 OUT_JPG='/tmp/test.jpg'
 REDUCE=0
 


### PR DESCRIPTION
@schwemmer 

Could you have a look at this branch? Because the shell-out to Kakadu is in a subprocess, my options are fairly limited. However, I wasn't cleaning up in the event that _something_ goes wrong during the transformation,  and I've [added a generic exception handling block](https://github.com/pulibrary/loris/compare/handle_corrupt_jp2?expand=1#diff-05d372ac8868d6959ce12ba84449ee34R423) per your suggestion. Additionally, you should see, e.g.:

```
2014-11-19 15:01:04,986 (transforms) [ERROR]: Kakadu Core Error:
2014-11-19 15:01:04,986 (transforms) [ERROR]: Missing or out-of-sequence tile-parts for tile number 38 in code-stream!
```

in your logs and something along the lines of:

```
Server Side Error: image was incomplete 

This is likely a permissions problem, though it's 
possible that there was a problem with the source file 
(/home/jstroop/workspace/loris/tests/img/corrupt.jp2). (500)
```

On your screen. Hopefully this keeps you machine from being overwhelmed--I haven't been able to reproduce it.
