### PR TITLE
Updates broken links for kakadu sources (x64) in Redhat README

### DIFF
--- a/doc/redhat-install.md
+++ b/doc/redhat-install.md
@@ -99,8 +99,8 @@ the 64-bit versions; if you need 32-bit change the portion of the URL from `x86-
 to `x86-32`.
 
 ```
-wget https://github.com/ksclarke/freelib-djatoka/tree/master/lib/Linux-x86-32/libkdu_v60R.so
-wget https://github.com/ksclarke/freelib-djatoka/tree/master/lib/Linux-x86-32/kdu_expand
+wget https://github.com/ksclarke/freelib-djatoka/tree/master/lib/Linux-x86-64/libkdu_v60R.so
+wget https://github.com/ksclarke/freelib-djatoka/tree/master/lib/Linux-x86-64/kdu_expand
 
 mv libkdu_v60R.so /usr/local/lib
 mv kdu_expand /usr/local/bin


### PR DESCRIPTION
I noticed I gave you the link for the 32 bit files.  We discovered it when the test.py failed.  These are the correct links and the test.py passes.  Sorry.
