### PR TITLE
Tweak _web_request_url for uri_resolvable case in SimpleHTTPResolver

### DIFF
--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -208,9 +208,11 @@ class SimpleHTTPResolver(_AbstractResolver):
     @staticmethod
     def _web_request_url(ident, is_uri_resolvable, prefix, suffix):
         if (ident[0:6] == 'http:/' or ident[0:7] == 'https:/') and is_uri_resolvable:
-            #ident is http request with no prefix or suffix specified
-            #For some reason, identifier is http:/<url> or https:/<url>? Hack to correct.
-            return ident[0:ident.find('/')] + '/' + ident[ident.find('/'):len(ident)]
+            # ident is http request with no prefix or suffix specified
+            # For some reason, identifier is http:/<url> or https:/<url>? 
+            # Hack to correct without breaking valid urls.
+            first_slash = ident.find('/')
+            return '%s//%s' % (ident[:first_slash], ident[first_slash:].lstrip('/'))
         else:
             return prefix + ident + suffix
 


### PR DESCRIPTION
I was trying out the current release of loris and I couldn't get it to work using full urls as the identifier, and I finally tracked it down to this section.

There's a note in the code that it's working around a problem where urls were coming in with only a single slash after http/https - that's not what's happening for me (and I tested this in a couple of different environments)--  and the fix was generating invalid urls with three slashes.  I've adjusted the url cleanup so it will only add two slashes - although technically my fix would clean up and work with any number of slashes after http/https, which may not be completely ideal either.
