### PR TITLE
TemplateHttpResolver (based on SimpleHttpResolver)

### DIFF
--- a/etc/loris2.conf
+++ b/etc/loris2.conf
@@ -50,6 +50,20 @@ src_img_root = '/usr/local/share/images' # r--
 #user='<if needed else remove this line>'
 #pw='<if needed else remove this line>'
 
+
+# Sample config for TemplateHTTResolver config
+
+# [resolver]
+# impl = 'loris.resolver.TemplateHTTPResolver'
+# cache_root='/usr/local/share/images/loris'
+# templates = 'a, b, fedora, devfedora'
+# a='http://example.edu/images/%s'
+# b='http://example.edu/images-elsewhere/%s'
+# fedora='http://<server>/fedora/objects/%s/datastreams/accessMaster/content'
+## optional settings
+# default_format
+# head_resolvable = False
+
 [img.ImageCache]
 cache_dp = '/var/cache/loris' # rwx
 


### PR DESCRIPTION
I've extend the SimpleHttpResolver to create a template-based http resolver, based in part on the syntax proposed in #98.  Currently it only supports url patterns, no other configurations are per-template.  If you think that needs to be added before this can be merged, I'm willing to add some logic for that but would like some feedback.  I held off on that in part because I wasn't sure of the best config file format to use; it looks like configobj supports nested settings groups, does that make sense here?  I did write unit tests, and documented the configuration in the class docstring.  Please let me know what additional functionality or documentation you think this needs before it's usable.

I had to refactor SimpleHttpResolver in a couple of places to make it easier to extend, so that I could override just the logic that is different and let the base class do all the real work of resolving and caching, so this is probably also of interest to @scande3.
