### PR TITLE
Make apt-get command cut-and-paste-able

### DIFF
--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -27,8 +27,8 @@ Pillow's external dependencies __MUST__ be built/installed before Pillow is inst
 
 Then, install all of the dependencies--note that exact versions may vary depending on your package manager and OS version:
 
-    $ sudo apt-get install libjpeg-turbo8-dev libfreetype6-dev zlib1g-dev
-    liblcms2-dev liblcms-utils libtiff5-dev python-dev libwebp-dev apache2
+    $ sudo apt-get install libjpeg-turbo8-dev libfreetype6-dev zlib1g-dev \
+    liblcms2-dev liblcms-utils libtiff5-dev python-dev libwebp-dev apache2 \
     libapache2-mod-wsgi
 
 Now install Pillow (setup.py would do this for you, but it's better to do separately and check):


### PR DESCRIPTION
This is a tiny edit, but it makes the install a little bit easier because the multi-line apt-get command can be cut and paste as a single line.
