### PR TITLE
quote file paths

### DIFF
--- a/loris/transforms.py
+++ b/loris/transforms.py
@@ -274,7 +274,7 @@ class OPJ_JP2Transformer(_AbstractJP2Transformer):
         # how to handle CalledProcessError; would have to be a 500?
 
         # opj_decompress command
-        i = '-i %s' % (src_fp,)
+        i = '-i "%s"' % (src_fp,)
         o = '-o %s' % (fifo_fp,)
         region_arg = self._region_to_opj_arg(image_request.region_param)
         reg = '-d %s' % (region_arg,) if region_arg else ''
@@ -381,7 +381,7 @@ class KakaduJP2Transformer(_AbstractJP2Transformer):
         # kdu command
         q = '-quiet'
         t = '-num_threads %s' % (self.num_threads,)
-        i = '-i %s' % (src_fp,)
+        i = '-i "%s"' % (src_fp,)
         o = '-o %s' % (fifo_fp,)
         reduce_arg = self._scales_to_reduce_arg(image_request)
         red = '-reduce %s' % (reduce_arg,) if reduce_arg else ''


### PR DESCRIPTION
If the path to the file has a space in it when using one of the JP2 transformers then the construction of the command line call will fail.

This patch is a very crude fix for that; it has solved our problem, but will probably fail if the path has a quote character in it.

This problem may be more than annoying; it's possible that it will allow execution of code in a shell as the user running loris.

I don't really know python so I don't have a suggestion for a complete fix. If Python has a way to construct commands with proper quoting automatically done (ala Ruby's Kernel.system method) it'd be prudent to use that to make system calls. Haven't looked to see if loris does this anywhere else.
