### PR TITLE
Fix TemplateHttpResolver warning for no templates configured

### DIFF
--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -345,7 +345,7 @@ class TemplateHTTPResolver(SimpleHTTPResolver):
         # technically it's not an error to have no templates configured,
         # but nothing will resolve; is that useful? or should this
         # cause an exception?
-        if templates:
+        if not templates:
             logger.warn('No templates specified in configuration')
         self.templates = {}
         for name in templates.split(','):


### PR DESCRIPTION
I was running this locally and noticed the test for warning that no templates configured is wrong. Whoops!
