### PR TITLE
extending TemplateHTTPResolver to allow delimited input

### DIFF
--- a/etc/loris2.conf
+++ b/etc/loris2.conf
@@ -50,17 +50,17 @@ src_img_root = '/usr/local/share/images' # r--
 #user='<if needed else remove this line>'
 #pw='<if needed else remove this line>'
 
-
 # Sample config for TemplateHTTResolver config
-
 # [resolver]
 # impl = 'loris.resolver.TemplateHTTPResolver'
 # cache_root='/usr/local/share/images/loris'
-# templates = 'a, b, fedora, devfedora'
+# templates = 'a, b, fedora, devfedora, fedora_obj_ds'
 # a='http://example.edu/images/%s'
 # b='http://example.edu/images-elsewhere/%s'
 # fedora='http://<server>/fedora/objects/%s/datastreams/accessMaster/content'
+# fedora_obj_ds = 'http://<server>/fedora/objects/%s/datastreams/%s/content' # as used with delimiter option below
 ## optional settings
+# delimiter = "|" # optional delimiter for splitting identifier, allowing for n-values to be inserted into the template
 # default_format
 # head_resolvable = False
 

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -373,8 +373,16 @@ class TemplateHTTPResolver(SimpleHTTPResolver):
 
     def _web_request_url(self, ident):
         prefix, ident = ident.split(':', 1)
-        if prefix in self.templates:
-            return self.templates[prefix] % ident
+
+        if 'delimiter' in self.config:
+            # uses delimiter of choice from config file to split identifier
+            # into tuple that will be fed to template
+            ident_components = ident.split(self.config['delimiter'])
+            if prefix in self.templates:
+                return self.templates[prefix] % tuple(ident_components)
+        else:
+            if prefix in self.templates:
+                return self.templates[prefix] % ident
         # if prefix is not recognized, no identifier is returned
         # and loris will return a 404
 


### PR DESCRIPTION
This extends the TemplateHTTPResolver by allowing users to include a delimiter character (e.g. `|`) in the config file that will split the identifier passed to template.  The reasoning behind this, now we can pass an object PID and datastream ID to create a URL that will resolve to a specific datastream from Fedora.  Moreover, it would allow the creation of fairly complex URL's if needed.  

https://github.com/loris-imageserver/loris/issues/98 was reviewed before making these changes, as it did feel a bit strange to allow the IIIF identifier to get used in this way.  BUT, it seems to work and just slightly extends functionality that was already present.
