### PR TITLE
Template http resolver ident clean up

### DIFF
--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -372,6 +372,9 @@ class TemplateHTTPResolver(SimpleHTTPResolver):
         self.uri_resolvable = True
 
     def _web_request_url(self, ident):
+        # only split identifiers that look like template ids; ignore other requests (e.g. favicon)
+        if ':' not in ident:
+            return
         prefix, ident = ident.split(':', 1)
         if prefix in self.templates:
             return self.templates[prefix] % ident


### PR DESCRIPTION
This is a small clean-up fix for errors generated by non-template id requests when running Loris with the TemplateHTTPResolver.  For example, when you access Loris in the browser, every time it requests a favicon.ico the current version generates errors when it tries to split the request to determine what template to use.
