### PR TITLE
Prevent creation of circular symlinks

### DIFF
--- a/loris/img.py
+++ b/loris/img.py
@@ -216,6 +216,11 @@ class ImageCache(dict):
 
 	@staticmethod
 	def _link(to,frum):
+		# under certain circumstances, files are generating circular
+		# symlinks; don't do that
+		if to == frum:
+			logger.warn('Circular symlink requested from %s to %s; not creating symlink' % (frum, to))
+			return
 		link_dp = path.dirname(frum)
 		if not path.exists(link_dp):
 			makedirs(link_dp)


### PR DESCRIPTION
## Preliminary fix for #187

This update doesn't address whatever issue is resulting in circular symlinks being created, but it adds a check to prevent actually creating them.  Based on the logic in ImageCache._link, I think in the cases where this is cropping up, loris is actually _removing_ a valid image file in order to create the broken circular symlink.  So, this fix will prevent that at least as a stop-gap until someone can determine what's causing it to happen.
