### PR TITLE
Symlinks were going the wrong direction

### DIFF
--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -585,7 +585,7 @@ possible that there was a problem with the source file
         '''
         # figure out paths, make dirs
         if self.enable_caching:
-            target_fp = self.img_cache.get_cache_path(image_request)
+            target_fp = self.img_cache.get_canonical_cache_path(image_request)
             target_dp = path.dirname(target_fp)
             if not path.exists(target_dp):
                 makedirs(target_dp)

--- a/test.py
+++ b/test.py
@@ -5,6 +5,7 @@ from tests import parameters_t
 from tests import resolver_t
 from tests import webapp_t
 from tests import transforms_t
+from tests import img_t
 from unittest import TestSuite, TextTestRunner
 
 test_suite = TestSuite()
@@ -13,5 +14,6 @@ test_suite.addTest(transforms_t.suite())
 test_suite.addTest(parameters_t.suite())
 test_suite.addTest(resolver_t.suite())
 test_suite.addTest(webapp_t.suite())
+test_suite.addTest(img_t.suite())
 
 TextTestRunner(verbosity=3).run(test_suite)

--- a/tests/img_t.py
+++ b/tests/img_t.py
@@ -1,0 +1,65 @@
+#-*- coding: utf-8 -*-
+
+from os.path import exists
+from os.path import islink
+from os.path import isfile
+from os.path import join
+from urllib import unquote
+
+import loris_t
+
+
+"""
+Image and ImageCache tests. This may need to be modified if you change the resolver
+implementation. To run this test on its own, do:
+
+$ python -m unittest tests.img_t
+
+from the `/loris` (not `/loris/loris`) directory.
+"""
+
+class Test_ImageCache(loris_t.LorisTest):
+    def test_cache_entry_added(self):
+
+        ident = self.test_jp2_color_id
+        request_path = '/%s/full/pct:10/0/default.jpg' % (ident,)
+        self.client.get(request_path)
+
+        # the canonical path
+        rel_cache_path = '%s/full/590,/0/default.jpg' % (unquote(ident),)
+        expect_cache_path = join(self.app.img_cache.cache_root, rel_cache_path)
+
+        self.assertTrue(exists(expect_cache_path))
+
+    def test_symlink_added(self):
+        ident = self.test_jp2_color_id
+        params = 'full/pct:10/0/default.jpg'
+        request_path = '/%s/%s' % (ident, params)
+
+        self.client.get(request_path)
+
+        # the symlink path
+        rel_cache_path = '%s/%s' % (unquote(ident), params)
+        expect_symlink = join(self.app.img_cache.cache_root, rel_cache_path)
+
+        self.assertTrue(islink(expect_symlink))
+
+    def test_canonical_requests_cache_at_canonical_path(self):
+        ident = self.test_jp2_color_id
+        # This is a canonical style request
+        request_path = '%s/full/202,/0/default.jpg' % (ident,)
+        self.client.get('/%s' % (request_path,))
+
+        rel_cache_path = '%s/full/202,/0/default.jpg' % (unquote(ident),)
+        expect_cache_path = join(self.app.img_cache.cache_root, rel_cache_path)
+
+        self.assertTrue(exists(expect_cache_path))
+        self.assertFalse(islink(expect_cache_path))
+
+
+def suite():
+    import unittest
+    test_suites = []
+    test_suites.append(unittest.makeSuite(Test_ImageCache, 'test'))
+    test_suite = unittest.TestSuite(test_suites)
+    return test_suite

--- a/tests/webapp_t.py
+++ b/tests/webapp_t.py
@@ -46,6 +46,7 @@ class Test_E_WebappUnit(loris_t.LorisTest):
         base_uri, ident, params, request_type = self.app._dissect_uri(req)
         expected = '/'.join((self.URI_BASE, self.test_jp2_color_id))
         self.assertEqual(base_uri, expected)
+    
 
 class Test_F_WebappFunctional(loris_t.LorisTest):
     'Simulate working with the webapp over HTTP.'
@@ -79,7 +80,7 @@ class Test_F_WebappFunctional(loris_t.LorisTest):
         self.assertEqual(resp.headers['content-type'], 'text/plain')
 
     def test_bare_identifier_request_303_gets_info(self):
-        # Follow the redirect. After that this is nearly a copy of 
+        # Follow the redirect. After that this is nearly a copy of
         # img_info_t.C_InfoFunctionalTests#test_jp2_info_dot_json_request
         to_get = '/%s' % (self.test_jp2_color_id,)
         resp = self.client.get(to_get, follow_redirects=True)
@@ -147,7 +148,7 @@ class Test_F_WebappFunctional(loris_t.LorisTest):
         # get an image
         resp = self.client.get(to_get, headers=Headers())
         self.assertEqual(resp.status_code, 200)
-        
+
 
     def test_info_sends_304(self):
         to_get = '/%s/info.json' % (self.test_jp2_color_id,)


### PR DESCRIPTION
@rlskoeser The symlinks were going the wrong way--i.e. from the canonical path TO the non-canonical version. Although I can't exactly imagine how this would result in circular links, I guess it's possible. [I added tests](https://github.com/loris-imageserver/loris/blob/remove_symlink_feature/tests/img_t.py#L22-L57) that were all failing until I made some very minor tweaks. It gets confusing very quickly, and I wouldn't mind a review if you have a moment.

If this doesn't solve your problem, It think we should remove the symlink stuff altogher (as I've been threatening)--it's a very minor savings at this point.

Closes #187.
