### PR TITLE
Add configuration option to turn off SSL certificate validation

### DIFF
--- a/etc/loris2.conf
+++ b/etc/loris2.conf
@@ -56,6 +56,7 @@ src_img_root = '/usr/local/share/images' # r--
 #cache_root='/usr/local/share/images/loris'
 #user='<if needed else remove this line>'
 #pw='<if needed else remove this line>'
+#ssl_check='<Check for SSL errors. Defaults to True. Set to False to ignore issues with self signed certificates>'
 
 # Sample config for TemplateHTTResolver config
 # [resolver]

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -150,6 +150,8 @@ class SimpleHTTPResolver(_AbstractResolver):
 
         self.pw = self.config.get('pw', None)
 
+        self.ssl_check = self.config.get('ssl_check', True)
+
         if 'cache_root' in self.config:
             self.cache_root = self.config['cache_root']
         else:
@@ -180,7 +182,7 @@ class SimpleHTTPResolver(_AbstractResolver):
 
             if self.head_resolvable:
                 try:
-                    with closing(requests.head(fp, **self.request_options())) as response:
+                    with closing(requests.head(fp, verify=self.ssl_check, **self.request_options())) as response:
                         if response.status_code is 200:
                             return True
                 except requests.exceptions.MissingSchema:
@@ -188,7 +190,7 @@ class SimpleHTTPResolver(_AbstractResolver):
 
             else:
                 try:
-                    with closing(requests.get(fp, stream=True, **self.request_options())) as response:
+                    with closing(requests.get(fp, stream=True, verify=self.ssl_check, **self.request_options())) as response:
                         if response.status_code is 200:
                             return True
                 except requests.exceptions.MissingSchema:
@@ -274,7 +276,7 @@ class SimpleHTTPResolver(_AbstractResolver):
             logger.debug('src image: %s' % (fp,))
 
             try:
-                response = requests.get(fp, stream = False, **self.request_options())
+                response = requests.get(fp, stream = False, verify=self.ssl_check, **self.request_options())
             except requests.exceptions.MissingSchema:
                 public_message = 'Bad URL request made for identifier: %s.' % (ident,)
                 log_message = 'Bad URL request at %s for identifier: %s.' % (fp,ident)


### PR DESCRIPTION
Many development environments use self signed certificates which causes issues with the default resolver.py setup. This patch adds a configuration option to have loris SimpleHTTResolver requests pass the verify=False flag to ignore SSL issues.
