### PR TITLE
sizeAboveFull

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -16,6 +16,8 @@ In addition to a bunch of directory paths (items that end with `_dp`) which shou
  * `enable_caching`. If `enable_caching=False` no Memory or filesystem caching will happen and `Last-Modified` headers not be sent. This should really only be used for testing/development/debugging.
  * `redirect_canonical_image_request`. If `redirect_canonical_image_request=True` and the request for an image is not the canonical path (e.g. only a width is supplied and the height is calculated by the server), the client will be redirected a `301`.
  * `redirect_id_slash_to_info` If True, `{id}/` and `{id}` will both redirect to the `{id}/info.json`. This is generally OK unless you have ids that end in slashes.
+ * `max_size_above_full` A numerical value which restricts the maximum image size to `max_size_above_full` percent of
+    the original image size. Setting this value to 100 disables server side interpolation of images. Default value is 200 (maximum double width or height allowed). To allow any size, set this value to 0.
 
 ### `[logging]`
 

--- a/etc/loris2.conf
+++ b/etc/loris2.conf
@@ -27,10 +27,13 @@ run_as_group = 'loris'
 enable_caching = True
 redirect_canonical_image_request = False
 redirect_id_slash_to_info = True
-max_size_above_full = 200  # Restrict interpolation of images  
-                    # Default value 200 means that user cannot request image 
-                    # sizes greater than 200% of original image size (width or height)
-                    # Set to 100 to disallow interpolation
+
+# max_size_above_full restricts interpolation of images on the server.
+# Default value 200 means that a user cannot request image sizes greater than 
+# 200% of original image size (width or height).
+# Set this value to 100 to disallow interpolation. Set to 0 to remove
+# size restriction.
+max_size_above_full = 200  
 
 # cors_regex = ''
 # NOTE: If supplied, cors_regex is passed to re.search():

--- a/etc/loris2.conf
+++ b/etc/loris2.conf
@@ -27,6 +27,11 @@ run_as_group = 'loris'
 enable_caching = True
 redirect_canonical_image_request = False
 redirect_id_slash_to_info = True
+size_above_full = False  # Set to true to allow interpolation on server
+max_above_full_size = 200  # If size_above_full is True do not accept requests
+                    # asking for more than max_img_size percent of the
+                    # original image size
+
 # cors_regex = ''
 # NOTE: If supplied, cors_regex is passed to re.search():
 #    https://docs.python.org/2/library/re.html#re.search

--- a/etc/loris2.conf
+++ b/etc/loris2.conf
@@ -27,10 +27,10 @@ run_as_group = 'loris'
 enable_caching = True
 redirect_canonical_image_request = False
 redirect_id_slash_to_info = True
-size_above_full = False  # Set to true to allow interpolation on server
-max_above_full_size = 200  # If size_above_full is True do not accept requests
-                    # asking for more than max_img_size percent of the
-                    # original image size
+max_size_above_full = 200  # Restrict interpolation of images  
+                    # Default value 200 means that user cannot request image 
+                    # sizes greater than 200% of original image size (width or height)
+                    # Set to 100 to disallow interpolation
 
 # cors_regex = ''
 # NOTE: If supplied, cors_regex is passed to re.search():

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -427,7 +427,8 @@ class Loris(object):
                         r.content_type = 'application/json'
                         l = '<http://iiif.io/api/image/2/context.json>;rel="http://www.w3.org/ns/json-ld#context";type="application/ld+json"'
                         r.headers['Link'] = '%s,%s' % (r.headers['Link'], l)
-                    # If no size above full is allowed, we have to remove this value from info.json
+                    # If interpolation is not allowed, we have to remove this 
+                    # value from info.json
                     if self.max_size_above_full <= 100:
                         info.profile[1]['supports'].remove('sizeAboveFull')
                     r.data = info.to_json()

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -397,8 +397,6 @@ class Loris(object):
         r.set_acao(request, self.cors_regex)
         try:
             info, last_mod = self._get_info(ident,request,base_uri)
-            if self.size_above_full is False:
-                del info.supports['sizeAboveFull']
         except ResolverException as re:
             return NotFoundResponse(re.message)
         except ImageInfoException as ie:

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -217,9 +217,8 @@ class Loris(object):
 
         self.transformers = self._load_transformers()
         self.resolver = self._load_resolver()
-        self.size_above_full = _loris_config.get('size_above_full', True)
         self.max_size_above_full = _loris_config.get('max_size_above_full', 200)
-        if self.size_above_full is False:
+        if self.max_size_above_full <= 100:
             constants.OPTIONAL_FEATURES.remove('sizeAboveFull')
 
         if self.enable_caching:
@@ -515,14 +514,9 @@ class Loris(object):
         image_request = img.ImageRequest(ident, region, size, rotation,
                                          quality, target_fmt)
         info, last_mod = self._get_info(ident, request, base_uri)
-        if self.size_above_full is False:
-            if Loris._size_exeeds_original(size, info.width, info.height, 100):
+        if Loris._size_exeeds_original(size, info.width, info.height, 
+                self.max_size_above_full):
                 return NotFoundResponse('Resolution not available')
-        else:
-            if Loris._size_exeeds_original(size, info.width, info.height,
-                                           self.max_size_above_full):
-                return NotFoundResponse('Resolution not available')
-
         r = LorisResponse()
         r.set_acao(request, self.cors_regex)
         # ImageRequest's Parameter attributes, i.e. RegionParameter etc. are

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -304,6 +304,7 @@ class InfoFunctional(loris_t.LorisTest):
         '''
         self.assertTrue(''.join(lh.split()) in link_header)
 
+
 class InfoCache(loris_t.LorisTest):
 
     def test_info_goes_to_http_fs_cache(self):

--- a/tests/img_t.py
+++ b/tests/img_t.py
@@ -5,7 +5,6 @@ from os.path import islink
 from os.path import isfile
 from os.path import join
 from urllib import unquote
-from loris.webapp import Loris
 import loris_t
 
 
@@ -55,51 +54,6 @@ class Test_ImageCache(loris_t.LorisTest):
 
         self.assertTrue(exists(expect_cache_path))
         self.assertFalse(islink(expect_cache_path))
-
-
-class Test_NoInterpolation(loris_t.LorisTest):
-
-    def setUp(self):
-        super(Test_NoInterpolation, self).setUp()
-        self.app.size_above_full = False
-        self.app.max_size_above_full = 200
-
-
-    def test_width(self):
-        self.assertFalse(Loris._size_exeeds_original('200,', 200, 100, 100))
-        self.assertTrue(Loris._size_exeeds_original('300,', 200, 100, 100))
-
-    def test_height(self):
-        self.assertFalse(Loris._size_exeeds_original(',100', 200, 100, 100))
-        self.assertTrue(Loris._size_exeeds_original(',200', 200, 100, 100))
-
-    def test_percentage(self):
-        self.assertFalse(Loris._size_exeeds_original('pct:50', 200, 100, 100))
-        self.assertFalse(Loris._size_exeeds_original('pct:100', 200, 100, 100))
-        self.assertTrue(Loris._size_exeeds_original('pct:101', 200, 100, 100))
-
-    def test_force_aspect(self):
-        self.assertFalse(Loris._size_exeeds_original('!50,150', 200, 100, 100))
-        self.assertFalse(Loris._size_exeeds_original('!20,50', 200, 100, 100))
-        self.assertFalse(Loris._size_exeeds_original('!200,100', 200, 100, 100))
-        self.assertTrue(Loris._size_exeeds_original('!250,150', 200, 100, 100))
-
-
-class Test_RestrictedInterpolation(loris_t.LorisTest):
-
-    def setUp(self):
-        super(Test_RestrictedInterpolation, self).setUp()
-        self.app.size_above_full = True
-        self.app.max_size_above_full = 200
-
-    def test_interpolation_limit(self):
-        self.assertFalse(Loris._size_exeeds_original('300,', 200, 100, 200))
-        self.assertTrue(Loris._size_exeeds_original('500,', 200, 100, 200))
-
-    def test_percentage(self):
-        self.assertFalse(Loris._size_exeeds_original('pct:50', 200, 100, 200))
-        self.assertFalse(Loris._size_exeeds_original('pct:200', 200, 100, 200))
-        self.assertTrue(Loris._size_exeeds_original('pct:201', 200, 100, 200))
 
 
 def suite():

--- a/tests/img_t.py
+++ b/tests/img_t.py
@@ -5,7 +5,7 @@ from os.path import islink
 from os.path import isfile
 from os.path import join
 from urllib import unquote
-
+from loris.webapp import Loris
 import loris_t
 
 
@@ -55,6 +55,51 @@ class Test_ImageCache(loris_t.LorisTest):
 
         self.assertTrue(exists(expect_cache_path))
         self.assertFalse(islink(expect_cache_path))
+
+
+class Test_NoInterpolation(loris_t.LorisTest):
+
+    def setUp(self):
+        super(Test_NoInterpolation, self).setUp()
+        self.app.size_above_full = False
+        self.app.max_size_above_full = 200
+
+
+    def test_width(self):
+        self.assertFalse(Loris._size_exeeds_original('200,', 200, 100, 100))
+        self.assertTrue(Loris._size_exeeds_original('300,', 200, 100, 100))
+
+    def test_height(self):
+        self.assertFalse(Loris._size_exeeds_original(',100', 200, 100, 100))
+        self.assertTrue(Loris._size_exeeds_original(',200', 200, 100, 100))
+
+    def test_percentage(self):
+        self.assertFalse(Loris._size_exeeds_original('pct:50', 200, 100, 100))
+        self.assertFalse(Loris._size_exeeds_original('pct:100', 200, 100, 100))
+        self.assertTrue(Loris._size_exeeds_original('pct:101', 200, 100, 100))
+
+    def test_force_aspect(self):
+        self.assertFalse(Loris._size_exeeds_original('!50,150', 200, 100, 100))
+        self.assertFalse(Loris._size_exeeds_original('!20,50', 200, 100, 100))
+        self.assertFalse(Loris._size_exeeds_original('!200,100', 200, 100, 100))
+        self.assertTrue(Loris._size_exeeds_original('!250,150', 200, 100, 100))
+
+
+class Test_RestrictedInterpolation(loris_t.LorisTest):
+
+    def setUp(self):
+        super(Test_RestrictedInterpolation, self).setUp()
+        self.app.size_above_full = True
+        self.app.max_size_above_full = 200
+
+    def test_interpolation_limit(self):
+        self.assertFalse(Loris._size_exeeds_original('300,', 200, 100, 200))
+        self.assertTrue(Loris._size_exeeds_original('500,', 200, 100, 200))
+
+    def test_percentage(self):
+        self.assertFalse(Loris._size_exeeds_original('pct:50', 200, 100, 200))
+        self.assertFalse(Loris._size_exeeds_original('pct:200', 200, 100, 200))
+        self.assertTrue(Loris._size_exeeds_original('pct:201', 200, 100, 200))
 
 
 def suite():


### PR DESCRIPTION
I noticed that Loris has no restriction for size. This means that a user can force the server to interpolate an image to any size (eg. /1000000,/) which can be used for DoS attacks. So I added code to limit the size parameter. What i did:
- Introduced a new config parameter Loris.max_size_above_full. It expects a numeric value which restricts the maximum size to n percent of the original image size (width or height: not number of pixels). 100 means that the maximum size of the original image size must not be exceeded, 200 allows a maximum width or height which is twice the original width or height. I set the default value to 200 in Loris.**init**(). If max_size_above_full ist set to 0, no size restrictions are set, so Loris behaves like it did before.
- Made changes to get_image() which returns a 404 ("resolution not available") if requested image size exceeds the maximum size. (Not sure if 404 is the best solution here)
- Made a change to get_info() which removes the sizeAboveFull value from info.json if max_size_above_full <= 100.
- Added some tests to webapp_t.py
