### PR TITLE
added ssl_check config to TemplateHTTPResolver

### DIFF
--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -375,6 +375,8 @@ class TemplateHTTPResolver(SimpleHTTPResolver):
         # required for simplehttpresolver
         # all templates are assumed to be uri resolvable
         self.uri_resolvable = True
+                
+        self.ssl_check = self.config.get('ssl_check', True)
 
     def _web_request_url(self, ident):
         # only split identifiers that look like template ids; ignore other requests (e.g. favicon)
@@ -449,7 +451,6 @@ class SourceImageCachingResolver(_AbstractResolver):
             logger.debug('src format %s' % (format,))
 
             return (local_fp, format)
-
 
 
 


### PR DESCRIPTION
Think these commits ([1](https://github.com/loris-imageserver/loris/commit/7b69cf6f472a39bd99e2f772bb12987b83d6c4ee), [2](https://github.com/loris-imageserver/loris/commit/581081fef5b05d985fe6bb63a4b257714380f3a7)) may have inadvertently broken the TemplateHTTPResolver.  

In a fresh install, I was seeing the following error, `AttributeError: 'TemplateHTTPResolver' object has no attribute 'ssl_check'`, which can be tracked down to [this ssl_check](https://github.com/loris-imageserver/loris/blob/development/loris/resolver.py#L193).  I had thought the TemplateHTTPResolver was inheriting some of these attributes from SimpleHTTPResolver, but noticed that wasn't the case.

Not sure if duplicating those config settings is the best way to do this, but it does address that particular error.  Wondered if SimpleHTTPResolver should have some `config.get()`'s set as class attributes, but that also seems like a dangerous game, not knowing what derived classes would need.
