### PR TITLE
libtiff4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
     - liblcms2-2
     - liblcms2-dev
     - liblcms-utils
-    - libtiff5-dev
+    - libtiff4-dev
     - libwebp-dev
 
 language: python


### PR DESCRIPTION
Suddenly Travis needs libtiff4-dev instead of 5
