### PR TITLE
Installation Instructions for RHEL 7

### DIFF
--- a/doc/redhat-7-install.md
+++ b/doc/redhat-7-install.md
@@ -1,0 +1,108 @@
+Install on Red Hat (CentOS) 7
+=============================
+
+Everything here needs to be done as root, so either open a root shell now or
+precede all instructions here with `sudo`.
+
+Install Dependencies
+--------------------
+
+ * mod_wsgi for apache
+ * python-devel for `pip install Pillow`
+ * bzip2 for library installed via Loris' `python setup.py install`
+
+```
+yum install git wget mod_wsgi python-devel bzip2
+```
+
+Install pip
+-----------
+
+At this point, you should have a `python2.7` binary in your `$PATH` somewhere
+(probably at `/usr/local/bin/python2.7`). We need to install pip so we can get
+the necessary dependencies for Loris. That's pretty simple: follow the
+instructions on the [pip wesite](http://www.pip-installer.org/en/latest/installing.html).
+Make sure you run the script with the correct Python or pip will install
+packages to the wrong place.
+
+```
+cd /opt
+wget https://bootstrap.pypa.io/get-pip.py
+python get-pip.py
+```
+
+Install image libraries
+-----------------------
+
+Next you'll need to install all the necessary image libraries so that loris
+will work properly. You can get what you need through yum:
+
+```
+yum install libjpeg-turbo libjpeg-turbo-devel \
+    freetype freetype-devel \
+    zlib-devel \
+    libtiff-devel
+```
+
+
+Install pip dependencies
+------------------------
+
+```
+pip install Werkzeug
+pip install Pillow
+```
+
+Install Loris
+-------------
+
+```
+useradd -d /var/www/loris -s /sbin/false loris
+git clone https://github.com/pulibrary/loris.git
+cd loris
+
+# (configure as necessary)
+
+python setup.py install
+```
+
+At this point you'll want to go through everything else suggested in the main
+install script: [configuring Apache](apache.md) and whatnot.
+
+After apache is configured, you can test by adding an image to `/usr/local/share/images` and visit a URL like:
+
+`http://{YOUR SERVER NAME}/loris/{YOUR TEST FILE NAME}/full/full/0/default.jpg`
+
+
+
+SELinux module
+---------------
+
+If SELinux is enabled you will need to create a custom security module that you load into Red Hat to
+allow httpd permissions to write to cache. You'll want to copy this into a
+file called `loris.te` (at any rate, make sure the file name matches the
+module name in the first line).
+
+```
+module loris 1.0;
+
+require {
+        type httpd_t;
+        type var_t;
+        class file { write read getattr open };
+}
+
+#============= httpd_t ==============
+allow httpd_t var_t:file { write read getattr open };
+```
+
+Then, you'll need to create a `.mod` file and compile it into the policy module
+itself a `.pp` file).
+
+```
+checkmodule -M -m -o loris.mod loris.te     # create mod file
+semodule_package -m loris.mod -o loris.pp   # compile it
+semodule -i loris.pp                              # install it
+```
+
+If all goes well, everything *should* be working properly!

--- a/doc/redhat-install.md
+++ b/doc/redhat-install.md
@@ -4,7 +4,7 @@ Install on Red Hat (CentOS)
 Installing Loris on Red Hat Enterprise Linux 6 (or the equivalent CentOS
 system) is tricky, since the bundled Python is not the right version and none
 of the `yum` packages are the latest versions. This guide is an attempt to
-guide you through the install process.
+guide you through the install process. If you're running RHEL 7, [see those instructions here](redhat-7-install.md).
 
 Everything here needs to be done as root, so either open a root shell now or
 precede all instructions here with `sudo`. It also assumes you have `yum`,
@@ -92,10 +92,10 @@ yum install libjpeg-turbo libjpeg-turbo-devel \
     libtiff-devel
 ```
 
-Loris ships with Kakadu version Version 7.2 which is compiled with glibc 2.14, 
-and Red Hat only has version 2.12. This means that the bundled `kdu_expand` program 
-won't work at all. Fortunately we can get an older version from Github. These are 
-the 64-bit versions; if you need 32-bit change the portion of the URL from `x86-64` 
+Loris ships with Kakadu version Version 7.2 which is compiled with glibc 2.14,
+and Red Hat only has version 2.12. This means that the bundled `kdu_expand` program
+won't work at all. Fortunately we can get an older version from Github. These are
+the 64-bit versions; if you need 32-bit change the portion of the URL from `x86-64`
 to `x86-32`.
 
 ```
@@ -107,7 +107,7 @@ mv kdu_expand /usr/local/bin
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 ```
 
-This earlier version of Kakadu does not support JPEG2000 images in colorspaces other 
+This earlier version of Kakadu does not support JPEG2000 images in colorspaces other
 that those allowed by an earlier version of the JPEG2000 specification. Chances are very good
 that this won't be a problem for you, but you should disable the [`map_profile_to_srgb`](https://github.com/pulibrary/loris/blob/development/etc/loris.conf#L66) feature just in case.
 
@@ -128,7 +128,7 @@ should have no problems.
 Install Loris
 -------------
 
-Now you're ready to install Loris proper. This is usually a matter of `git clone`ing 
+Now you're ready to install Loris proper. This is usually a matter of `git clone`ing
 this repo, adding the loris user, and running `setup.py`. The only
 caveat here is that you must be sure to install using Python 2.7.
 


### PR DESCRIPTION
Hello,

I was able to update the RHEL 6 install instructions for RHEL 7.

I have a loris server running on RHEL 7 following the instructions in this merge request, and was able to validate the server via iiif.io ([see validator screenshot](http://d.pr/i/16yJY)).

I appreciate your consideration merging in these instructions.

Thanks!
Joe Corall
