### PR TITLE
removing hardcoded '0755' permissions from info cache

### DIFF
--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -421,7 +421,7 @@ class InfoCache(object):
         dp = os.path.dirname(info_fp)
         if not os.path.isdir(dp):
             try:
-                os.makedirs(dp, 0755)
+                os.makedirs(dp)
                 logger.debug('Created %s' % (dp,))
             except OSError as e: # this happens once and a while; not sure why
                 if e.errno == errno.EEXIST:


### PR DESCRIPTION
Aligns with `os.makedirs()` from image caching that falls back on permission defaults for OS user behind Loris
