### PR TITLE
ident_regex configuration

### DIFF
--- a/doc/resolver.md
+++ b/doc/resolver.md
@@ -54,6 +54,7 @@ source_suffix=''
 uri_resolvable=False
 head_resolvable=False #DO set this to true if using Fedora Commons 3.8 or later. Earlier versions have a bug for a head response.
 default_format=None #Set this if your HTTP server doesn't populate content-response. An example value might be "jp2".
+ident_regex=False #Set this to a regular expression matching your identifier pattern to reduce unnecessary network traffic on source server
 user=None
 pw=None
 cache_root='<must be configured>'

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -16,6 +16,7 @@ import constants
 import hashlib
 import glob
 import requests
+import re
 
 logger = getLogger(__name__)
 
@@ -159,6 +160,8 @@ class SimpleHTTPResolver(_AbstractResolver):
 
         self.ssl_check = self.config.get('ssl_check', True)
 
+        self.ident_regex = self.config.get('ident_regex', False)
+
         if 'cache_root' in self.config:
             self.cache_root = self.config['cache_root']
         else:
@@ -181,6 +184,12 @@ class SimpleHTTPResolver(_AbstractResolver):
 
     def is_resolvable(self, ident):
         ident = unquote(ident)
+
+        if self.ident_regex:
+            regex = re.compile(self.ident_regex)
+            if not regex.match(ident):
+                return False
+
         fp = join(self.cache_root, SimpleHTTPResolver._cache_subroot(ident))
         if exists(fp):
             return True


### PR DESCRIPTION
This PR adds a configuration to the SimpleHTTPResolver.

By setting `ident_regex` the user can compare idents coming through `is_resolvable` to prevent unnecessary network traffic hitting their source server.
