### PR TITLE
Add ability to explicitly proxy request through loris.

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -18,7 +18,7 @@ In addition to a bunch of directory paths (items that end with `_dp`) which shou
  * `redirect_id_slash_to_info` If True, `{id}/` and `{id}` will both redirect to the `{id}/info.json`. This is generally OK unless you have ids that end in slashes.
  * `max_size_above_full` A numerical value which restricts the maximum image size to `max_size_above_full` percent of
     the original image size. Setting this value to 100 disables server side interpolation of images. Default value is 200 (maximum double width or height allowed). To allow any size, set this value to 0.
-
+ * `proxy_path` The path you would like loris to proxy to. This will override the default path to your info.json file. proxy_path defaults to None if not explicitly set.
 ### `[logging]`
 
 Each module has its own logger and is chock-full of debug statements, so setting the level to to `INFO` or higher is highly recommended.

--- a/etc/loris2.conf
+++ b/etc/loris2.conf
@@ -33,8 +33,9 @@ redirect_id_slash_to_info = True
 # 200% of original image size (width or height).
 # Set this value to 100 to disallow interpolation. Set to 0 to remove
 # size restriction.
-max_size_above_full = 200  
+max_size_above_full = 200
 
+#proxy_path=''
 # cors_regex = ''
 # NOTE: If supplied, cors_regex is passed to re.search():
 #    https://docs.python.org/2/library/re.html#re.search

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -211,6 +211,7 @@ class Loris(object):
         self.enable_caching = _loris_config['enable_caching']
         self.redirect_canonical_image_request = _loris_config['redirect_canonical_image_request']
         self.redirect_id_slash_to_info = _loris_config['redirect_id_slash_to_info']
+        self.proxy_path = _loris_config.get('proxy_path', None)
         self.cors_regex = _loris_config.get('cors_regex', None)
         if self.cors_regex:
             self.cors_regex = re.compile(self.cors_regex)
@@ -356,7 +357,9 @@ class Loris(object):
         logger.debug('_dissect_uri ident: %s' % (ident,))
         logger.debug('_dissect_uri params: %s' % (params,))
 
-        if r.script_root != u'':
+        if self.proxy_path is not None:
+            base_uri = '%s%s' % (self.proxy_path,ident)
+        elif r.script_root != u'':
             base_uri = '%s%s' % (r.url_root,ident)
         else:
             base_uri = '%s%s' % (r.host_url,ident)


### PR DESCRIPTION
@jpstroop We figured out how to proxy requests through loris without changing loris or Leaflet-IIIF. However, I went ahead and made the changes you suggested to allow other folks to proxy by directly overriding the path to their info.json files.
