### PR TITLE
Unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 
 *.egg-info/
 
+env/
+.cache/
+
 build/
 
 dist/

--- a/test.py
+++ b/test.py
@@ -6,6 +6,9 @@ from tests import resolver_t
 from tests import webapp_t
 from tests import transforms_t
 from tests import img_t
+from tests import simple_fs_resolver_ut
+from tests import simple_http_resolver_ut
+from tests import source_image_caching_resolver_ut
 from unittest import TestSuite, TextTestRunner
 
 test_suite = TestSuite()
@@ -15,5 +18,8 @@ test_suite.addTest(parameters_t.suite())
 test_suite.addTest(resolver_t.suite())
 test_suite.addTest(webapp_t.suite())
 test_suite.addTest(img_t.suite())
+test_suite.addTest(simple_fs_resolver_ut.suite())
+test_suite.addTest(simple_http_resolver_ut.suite())
+test_suite.addTest(source_image_caching_resolver_ut.suite())
 
 TextTestRunner(verbosity=3).run(test_suite)

--- a/tests/abstract_resolver.py
+++ b/tests/abstract_resolver.py
@@ -1,0 +1,21 @@
+class AbstractResolverTest(object):
+    def test_is_resolvable(self):
+        self.assertTrue(
+         self.resolver.is_resolvable(self.identifier)
+        )
+
+    def test_is_not_resolvable(self):
+        self.assertFalse(
+                self.resolver.is_resolvable(self.not_identifier)
+        )
+
+    def test_format(self):
+        self.assertEqual(
+                self.resolver._format_from_ident(self.identifier),
+                self.expected_format
+        )
+
+    def test_resolve(self):
+        expected_resolved = (self.expected_filepath, self.expected_format)
+        resolved = self.resolver.resolve(self.identifier)
+        self.assertSequenceEqual(resolved, expected_resolved)

--- a/tests/simple_fs_resolver_ut.py
+++ b/tests/simple_fs_resolver_ut.py
@@ -1,0 +1,52 @@
+from .abstract_resolver import AbstractResolverTest
+from loris import resolver
+import os
+import unittest
+
+
+class SimpleFSResolverTest(AbstractResolverTest, unittest.TestCase):
+    TEST_DIR = os.path.dirname(os.path.realpath(__file__))
+
+    def setUp(self):
+        super(SimpleFSResolverTest, self).setUp()
+        img_dir = os.path.join(self.TEST_DIR, 'img')
+
+        single_config = {
+            'src_img_root': img_dir,
+        }
+
+        self.identifier = '01/02/0001.jp2'
+        self.not_identifier = 'DOES_NOT_EXIST.jp2'
+        self.expected_filepath = os.path.join(
+                img_dir,
+                self.identifier
+                )
+        self.expected_format = 'jp2'
+
+        self.resolver = resolver.SimpleFSResolver(single_config)
+
+
+class MultiSourceSimpleFSResolverTest(SimpleFSResolverTest):
+    def setUp(self):
+        super(MultiSourceSimpleFSResolverTest, self).setUp()
+        img_dir = os.path.join(self.TEST_DIR, 'img')
+        img_dir2 = os.path.join(self.TEST_DIR, 'img2')
+
+        multiple_config = {
+            'src_img_roots': [img_dir2, img_dir]
+        }
+        self.resolver = resolver.SimpleFSResolver(multiple_config)
+
+
+def suite():
+    test_suites = []
+    test_suites.append(
+            unittest.makeSuite(SimpleFSResolverTest, 'test')
+    )
+    test_suites.append(
+            unittest.makeSuite(MultiSourceSimpleFSResolverTest, 'test')
+    )
+    return unittest.TestSuite(test_suites)
+
+if __name__ == '__main__':
+        unittest.main()

--- a/tests/simple_http_resolver_ut.py
+++ b/tests/simple_http_resolver_ut.py
@@ -1,0 +1,202 @@
+# from .abstract_resolver import AbstractResolverTest
+from loris.resolver import SimpleHTTPResolver
+from loris.loris_exception import ResolverException
+import os
+import shutil
+import unittest
+import responses
+
+
+class SimpleHTTPResolverTest(unittest.TestCase):
+    def setUp(self):
+        super(SimpleHTTPResolverTest, self).setUp()
+        tests_dir = os.path.dirname(os.path.realpath(__file__))
+        self.cache_dir = os.path.join(tests_dir, 'cache')
+        prefix_url = 'http://sample.sample/'
+
+        config = {
+            'cache_root': self.cache_dir,
+            'source_prefix': prefix_url,
+            'source_suffix': '',
+            'head_resolvable': True,
+            'uri_resolvable': True
+        }
+        self.resolver = SimpleHTTPResolver(config)
+        self.not_identifier = 'DOES_NOT_EXIST'
+        self.not_identifier_url = ''.join(
+                [
+                    prefix_url,
+                    self.not_identifier
+                ]
+        )
+        self.identifier = '0001'
+        self.identifier_url = ''.join(
+                [
+                    prefix_url,
+                    self.identifier
+                ]
+        )
+        self.expected_format = 'tif'
+        expected_filepath_list = [
+                    self.cache_dir,
+                    '25',
+                    'bbd',
+                    'cd0',
+                    '6c3',
+                    '2d4',
+                    '77f',
+                    '7fa',
+                    '1c3',
+                    'e4a',
+                    '91b',
+                    '032',
+                    'loris_cache.tif',
+                ]
+        self.expected_filepath = os.path.join(*expected_filepath_list)
+        self.set_responses()
+
+    def set_responses(self):
+        responses.add(
+                responses.HEAD,
+                self.identifier_url,
+                status=200,
+                content_type='image/tiff'
+        )
+        responses.add(
+                responses.GET,
+                self.identifier_url,
+                body='II*\x00\x0c\x00\x00\x00\x80\x00  \x0e\x00\x00\x01\x03\x00\x01\x00\x00\x00\x01\x00\x00\x00\x01\x01\x03\x00\x01\x00\x00\x00\x01\x00\x00\x00\x02\x01\x03\x00\x01\x00\x00\x00\x08\x00\x00\x00\x03\x01\x03\x00\x01\x00\x00\x00\x05\x00\x00\x00\x06\x01\x03\x00\x01\x00\x00\x00\x03\x00\x00\x00\x11\x01\x04\x00\x01\x00\x00\x00\x08\x00\x00\x00\x15\x01\x03\x00\x01\x00\x00\x00\x01\x00\x00\x00\x16\x01\x03\x00\x01\x00\x00\x00\x08\x00\x00\x00\x17\x01\x04\x00\x01\x00\x00\x00\x04\x00\x00\x00\x1a\x01\x05\x00\x01\x00\x00\x00\xba\x00\x00\x00\x1b\x01\x05\x00\x01\x00\x00\x00\xc2\x00\x00\x00\x1c\x01\x03\x00\x01\x00\x00\x00\x01\x00\x00\x00(\x01\x03\x00\x01\x00\x00\x00\x02\x00\x00\x00@\x01\x03\x00\x00\x03\x00\x00\xca\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00H\x00\x00\x00\x01\x00\x00\x00H\x00\x00\x00\x01\x00\x00\x00\xff`\xe6q\x19\x08\x00\x00\x80\t\x00\x00\x80\n\x00\x00\x80\x0b\x00\x00\x80\x0c\x00\x00\x80\r',
+                status=200,
+                content_type='image/tiff'
+        )
+        responses.add(
+                responses.HEAD,
+                self.not_identifier_url,
+                status=404,
+                content_type='application/html'
+        )
+        responses.add(
+                responses.GET,
+                self.not_identifier_url,
+                body='Does Not Exist',
+                status=404,
+                content_type='application/html'
+        )
+
+    @responses.activate
+    def test_bad_url(self):
+
+        self.assertRaises(
+                ResolverException,
+                lambda: self.resolver.resolve(self.not_identifier_url)
+        )
+
+    @responses.activate
+    def test_does_not_exist(self):
+        self.assertRaises(
+                ResolverException,
+                lambda: self.resolver.resolve(self.not_identifier)
+        )
+
+    @responses.activate
+    def test_resolve_001(self):
+        expected_resolved = (self.expected_filepath, self.expected_format)
+        resolved = self.resolver.resolve(self.identifier)
+        self.assertSequenceEqual(resolved, expected_resolved)
+        # Make sure the file exists in the cache
+        self.assertTrue(os.path.isfile(self.expected_filepath))
+
+    @responses.activate
+    def test_is_resolvable_001(self):
+        self.assertTrue(
+         self.resolver.is_resolvable(self.identifier)
+        )
+        # Make sure the file DOES NOT exists in the cache
+        self.assertFalse(os.path.isfile(self.expected_filepath))
+
+    @responses.activate
+    def test_is_not_resolvable(self):
+        self.assertFalse(
+                self.resolver.is_resolvable(self.not_identifier)
+        )
+
+    def tearDown(self):
+        # Clean Up the cache directory
+        if os.path.exists(self.cache_dir):
+            shutil.rmtree(self.cache_dir)
+
+
+class SimpleHTTPResolverConfigTest(unittest.TestCase):
+
+    def setUp(self):
+        super(SimpleHTTPResolverConfigTest, self).setUp()
+        tests_dir = os.path.dirname(os.path.realpath(__file__))
+        self.cache_dir = os.path.join(tests_dir, 'cache')
+
+    def test_no_config(self):
+        config = {}
+        self.assertRaises(
+                ResolverException,
+                lambda: SimpleHTTPResolver(config)
+        )
+
+    def test_missing_required_config(self):
+        config = {
+            'cache_root': self.cache_dir
+        }
+        self.assertRaises(
+                ResolverException,
+                lambda: SimpleHTTPResolver(config)
+        )
+
+    def test_config_assigned_to_resolver(self):
+        config = {
+            'cache_root': self.cache_dir,
+            'source_prefix': 'http://www.mysite/',
+            'source_suffix': '/accessMaster',
+            'default_format': 'jp2',
+            'head_resolvable': True,
+            'uri_resolvable': True,
+            'user': 'TestUser',
+            'pw': 'TestPW',
+        }
+
+        resolver = SimpleHTTPResolver(config)
+        self.assertEqual(resolver.cache_root, self.cache_dir)
+        self.assertEqual(resolver.source_prefix, 'http://www.mysite/')
+        self.assertEqual(resolver.source_suffix, '/accessMaster')
+        self.assertEqual(resolver.default_format, 'jp2')
+        self.assertEqual(resolver.head_resolvable, True)
+        self.assertEqual(resolver.uri_resolvable, True)
+        self.assertEqual(resolver.user, 'TestUser')
+        self.assertEqual(resolver.pw, 'TestPW')
+
+    def test_barebones_config(self):
+        config = {
+            'cache_root': self.cache_dir,
+            'uri_resolvable': True
+        }
+
+        resolver = SimpleHTTPResolver(config)
+        self.assertEqual(resolver.cache_root, self.cache_dir)
+        self.assertEqual(resolver.source_prefix, '')
+        self.assertEqual(resolver.source_suffix, '')
+        self.assertEqual(resolver.default_format, None)
+        self.assertEqual(resolver.head_resolvable, False)
+        self.assertEqual(resolver.uri_resolvable, True)
+        self.assertEqual(resolver.user, None)
+        self.assertEqual(resolver.pw, None)
+
+
+def suite():
+    test_suites = []
+    test_suites.append(
+            unittest.makeSuite(SimpleHTTPResolverConfigTest, 'test')
+    )
+    test_suites.append(
+            unittest.makeSuite(SimpleHTTPResolverTest, 'test')
+    )
+    return unittest.TestSuite(test_suites)
+
+if __name__ == '__main__':
+        unittest.main()

--- a/tests/source_image_caching_resolver_ut.py
+++ b/tests/source_image_caching_resolver_ut.py
@@ -1,0 +1,48 @@
+from .abstract_resolver import AbstractResolverTest
+from loris import resolver
+import os
+import shutil
+import unittest
+
+
+class SourceImageCachingResolverTest(AbstractResolverTest, unittest.TestCase):
+    def setUp(self):
+        super(SourceImageCachingResolverTest, self).setUp()
+        tests_dir = os.path.dirname(os.path.realpath(__file__))
+        self.cache_dir = os.path.join(tests_dir, 'cache')
+        config = {
+            'source_root': os.path.join(tests_dir, 'img'),
+            'cache_root': self.cache_dir
+        }
+
+        self.identifier = '01/02/0001.jp2'
+        self.expected_filepath = os.path.join(
+                self.cache_dir,
+                self.identifier
+        )
+        self.not_identifier = 'DOES_NOT_EXIST.jp2'
+        self.expected_format = 'jp2'
+
+        self.resolver = resolver.SourceImageCachingResolver(config)
+
+    def test_resolve(self):
+        super(SourceImageCachingResolverTest, self).test_resolve()
+
+        # Make sure the file exists in the cache
+        self.assertTrue(os.path.isfile(self.expected_filepath))
+
+    def tearDown(self):
+        # Clean Up the cache directory
+        if os.path.exists(self.cache_dir):
+            shutil.rmtree(self.cache_dir)
+
+
+def suite():
+    test_suites = []
+    test_suites.append(
+            unittest.makeSuite(SourceImageCachingResolverTest, 'test')
+    )
+    return unittest.TestSuite(test_suites)
+
+if __name__ == '__main__':
+        unittest.main()


### PR DESCRIPTION
Create isolated unit tests for resolvers.
Relies on dictionaries for config.
Does not rely on the rest of the application config.
