### PR TITLE
Resolvers Refactor

### DIFF
--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -5,7 +5,7 @@
 """
 from logging import getLogger
 from loris_exception import ResolverException
-from os.path import join, exists, isfile
+from os.path import join, exists
 from os import makedirs
 from os.path import dirname
 from shutil import copy
@@ -20,14 +20,15 @@ import re
 
 logger = getLogger(__name__)
 
+
 class _AbstractResolver(object):
     def __init__(self, config):
         self.config = config
 
     def is_resolvable(self, ident):
         """
-        The idea here is that in some scenarios it may be cheaper to check 
-        that an id is resolvable than to actually resolve it. For example, for 
+        The idea here is that in some scenarios it may be cheaper to check
+        that an id is resolvable than to actually resolve it. For example, for
         an HTTP resolver, this could be a HEAD instead of a GET.
 
         Args:
@@ -41,10 +42,10 @@ class _AbstractResolver(object):
 
     def resolve(self, ident):
         """
-        Given the identifier of an image, get the path (fp) and format (one of. 
+        Given the identifier of an image, get the path (fp) and format (one of.
         'jpg', 'tif', or 'jp2'). This will likely need to be reimplemented for
         environments and can be as smart or dumb as you want.
-        
+
         Args:
             ident (str):
                 The identifier for the image.
@@ -58,67 +59,74 @@ class _AbstractResolver(object):
 
 
 class SimpleFSResolver(_AbstractResolver):
+    """
+    For this dumb version a constant path is prepended to the identfier
+    supplied to get the path It assumes this 'identifier' ends with a file
+    extension from which the format is then derived.
+    """
 
     def __init__(self, config):
         super(SimpleFSResolver, self).__init__(config)
         if 'src_img_roots' in self.config:
-            self.cache_roots = self.config['src_img_roots']
+            self.source_roots = self.config['src_img_roots']
         else:
-            self.cache_roots = [self.config['src_img_root']]
+            self.source_roots = [self.config['src_img_root']]
 
-    def get_fp(self, ident):
+    def raise_404_for_ident(self, ident):
+        message = 'Source image not found for identifier: %s.' % (ident,)
+        logger.warn(message)
+        raise ResolverException(404, message)
+
+    def source_file_path(self, ident):
         ident = unquote(ident)
-        for directory in self.cache_roots:
+        for directory in self.source_roots:
             fp = join(directory, ident)
             if exists(fp):
                 return fp
 
     def is_resolvable(self, ident):
-        return not self.get_fp(ident) is None
+        return not self.source_file_path(ident) is None
 
-    @staticmethod
-    def _format_from_ident(ident):
+    def format_from_ident(self, ident):
         return ident.split('.')[-1]
 
     def resolve(self, ident):
-        # For this dumb version a constant path is prepended to the identfier 
-        # supplied to get the path It assumes this 'identifier' ends with a file 
-        # extension from which the format is then derived.
-        fp = self.get_fp(ident)
-        logger.debug('src image: %s' % (fp,))
 
-        if fp is None:
-            public_message = 'Source image not found for identifier: %s.' % (ident,)
-            log_message = 'Source image not found at %s for identifier: %s.' % (fp,ident)
-            logger.warn(log_message)
-            raise ResolverException(404, public_message)
+        if not self.is_resolvable(ident):
+            self.raise_404_for_ident(ident)
 
-        format = SimpleFSResolver._format_from_ident(ident)
+        source_fp = self.source_file_path(ident)
+        logger.debug('src image: %s' % (source_fp,))
+
+        format = self.format_from_ident(ident)
         logger.debug('src format %s' % (format,))
 
-        return (fp, format)
+        return (source_fp, format)
 
-#To use this the resolver stanza of the config will have to have both the
-#src_img_root as required by the SimpleFSResolver and also an
-#[[extension_map]], which will be a hash mapping found extensions to the
-#extensions that loris wants to see, e.g.
+
+# To use this the resolver stanza of the config will have to have both the
+# src_img_root as required by the SimpleFSResolver and also an
+# [[extension_map]], which will be a hash mapping found extensions to the
+# extensions that loris wants to see, e.g.
+#
 # [resolver]
 # impl = 'loris.resolver.ExtensionNormalizingFSResolver'
 # src_img_root = '/cnfs-ro/iiif/production/medusa-root' # r--
 #   [[extension_map]]
 #   jpeg = 'jpg'
 #   tiff = 'tif'
-#Note that case normalization happens before looking up in the extension_map.
+# Note that case normalization happens before looking up in the extension_map.
 class ExtensionNormalizingFSResolver(SimpleFSResolver):
     def __init__(self, config):
         super(ExtensionNormalizingFSResolver, self).__init__(config)
         self.extension_map = self.config['extension_map']
 
-    def resolve(self, ident):
-        fp, format = super(ExtensionNormalizingFSResolver, self).resolve(ident)
+    def format_from_ident(self, ident):
+        format = super(ExtensionNormalizingFSResolver, self).format_from_ident(ident)
         format = format.lower()
         format = self.extension_map.get(format, format)
-        return (fp, format)
+        return format
+
 
 class SimpleHTTPResolver(_AbstractResolver):
     '''
@@ -222,27 +230,26 @@ class SimpleHTTPResolver(_AbstractResolver):
         elif ident.rfind('.') != -1 and (len(ident) - ident.rfind('.') <= 5):
             return ident.split('.')[-1]
         else:
-            public_message = 'Format could not be determined for: %s.' % (ident,)
-            log_message = 'Format could not be determined for: %s.' % (ident)
-            logger.warn(log_message)
-            raise ResolverException(404, public_message)
+            message = 'Format could not be determined for: %s.' % (ident)
+            logger.warn(message)
+            raise ResolverException(404, message)
 
     def _web_request_url(self, ident):
         if (ident[0:6] == 'http:/' or ident[0:7] == 'https:/') and self.uri_resolvable:
             # ident is http request with no prefix or suffix specified
-            # For some reason, identifier is http:/<url> or https:/<url>? 
+            # For some reason, identifier is http:/<url> or https:/<url>?
             # Hack to correct without breaking valid urls.
             first_slash = ident.find('/')
             return '%s//%s' % (ident[:first_slash], ident[first_slash:].lstrip('/'))
         else:
             return self.source_prefix + ident + self.source_suffix
 
-    #Get a subdirectory structure for the cache_subroot through hashing.
+    # Get a subdirectory structure for the cache_subroot through hashing.
     @staticmethod
     def _cache_subroot(ident):
         cache_subroot = ''
 
-        #Split out potential pidspaces... Fedora Commons most likely use case.
+        # Split out potential pidspaces... Fedora Commons most likely use case.
         if ident[0:6] != 'http:/' and ident[0:7] != 'https:/' and len(ident.split(':')) > 1:
             for split_ident in ident.split(':')[0:-1]:
                 cache_subroot = join(cache_subroot, split_ident)
@@ -253,12 +260,12 @@ class SimpleHTTPResolver(_AbstractResolver):
 
         return cache_subroot
 
-    #Get the directory structure of the identifier itself
+    # Get the directory structure of the identifier itself
     @staticmethod
     def _ident_file_structure(ident):
         file_structure = ''
         ident_hash = hashlib.md5(quote_plus(ident)).hexdigest()
-        #First level 2 digit directory then do three digits...
+        # First level 2 digit directory then do three digits...
         file_structure_list = [ident_hash[0:2]] + [ident_hash[i:i+3] for i in range(2, len(ident_hash), 3)]
 
         for piece in file_structure_list:
@@ -266,72 +273,110 @@ class SimpleHTTPResolver(_AbstractResolver):
 
         return file_structure
 
-    def resolve(self, ident):
+    def cache_dir_path(self, ident):
         ident = unquote(ident)
+        return join(
+                self.cache_root,
+                SimpleHTTPResolver._cache_subroot(ident)
+        )
 
-        local_fp = join(self.cache_root, SimpleHTTPResolver._cache_subroot(ident))
-        local_fp = join(local_fp)
+    def cache_file_path(self, ident):
+        pass
 
-        if exists(local_fp):
-            cached_object = glob.glob(join(local_fp, 'loris_cache.*'))
+    def raise_404_for_ident(self, ident):
+        message = 'Image not found for identifier: %s.' % (ident)
+        raise ResolverException(404, message)
 
-            if len(cached_object) > 0:
-                cached_object = cached_object[0]
+    def cached_files_for_ident(self, ident):
+        cache_dir = self.cache_dir_path(ident)
+        if exists(cache_dir):
+            return glob.glob(join(cache_dir, 'loris_cache.*'))
+        return []
+
+    def in_cache(self, ident):
+        cache_dir = self.cache_dir_path(ident)
+        if exists(cache_dir):
+            cached_files = self.cached_files_for_ident(ident)
+            if cached_files:
+                return True
             else:
-                public_message = 'Cached image not found for identifier: %s.' % (ident)
                 log_message = 'Cached image not found for identifier: %s. Empty directory where image expected?' % (ident)
                 logger.warn(log_message)
-                raise ResolverException(404, public_message)
+                self.raise_404_for_ident(ident)
+        return False
 
-            format = self.format_from_ident(cached_object,None)
-            logger.debug('src image from local disk: %s' % (cached_object,))
-            return (cached_object, format)
+    def cached_object(self, ident):
+        cached_files = self.cached_files_for_ident(ident)
+        if cached_files:
+            cached_object = cached_files[0]
         else:
-            fp = self._web_request_url(ident)
+            self.raise_404_for_ident(ident)
+        return cached_object
 
-            logger.debug('src image: %s' % (fp,))
-
+    def cache_file_extension(self, ident, response):
+        if 'content-type' in response.headers:
             try:
-                response = requests.get(fp, stream = False, verify=self.ssl_check, **self.request_options())
-            except requests.exceptions.MissingSchema:
-                public_message = 'Bad URL request made for identifier: %s.' % (ident,)
-                log_message = 'Bad URL request at %s for identifier: %s.' % (fp,ident)
-                logger.warn(log_message)
-                raise ResolverException(404, public_message)
+                extension = self.format_from_ident(ident, constants.FORMATS_BY_MEDIA_TYPE[response.headers['content-type']])
+            except KeyError:
+                logger.warn('Your server may be responding with incorrect content-types. Reported %s for ident %s.'
+                            % (response.headers['content-type'], ident))
+                # Attempt without the content-type
+                extension = self.format_from_ident(ident, None)
+        else:
+            extension = self.format_from_ident(ident, None)
+        return extension
 
-            if response.status_code != 200:
-                public_message = 'Source image not found for identifier: %s. Status code returned: %s' % (ident,response.status_code)
-                log_message = 'Source image not found at %s for identifier: %s. Status code returned: %s' % (fp,ident,response.status_code)
-                logger.warn(log_message)
-                raise ResolverException(404, public_message)
+    def copy_to_cache(self, ident):
+        ident = unquote(ident)
+        source_url = self._web_request_url(ident)
 
-            if 'content-type' in response.headers:
-                try:
-                    format = self.format_from_ident(ident, constants.FORMATS_BY_MEDIA_TYPE[response.headers['content-type']])
-                except KeyError:
-                    logger.warn('Your server may be responding with incorrect content-types. Reported %s for ident %s.'
-                                % (response.headers['content-type'],ident))
-                    #Attempt without the content-type
-                    format = self.format_from_ident(ident, None)
-            else:
-                format = self.format_from_ident(ident, None)
+        logger.debug('src image: %s' % (source_url,))
 
-            logger.debug('src format %s' % (format,))
+        try:
+            response = requests.get(
+                    source_url,
+                    stream=False,
+                    verify=self.ssl_check,
+                    **self.request_options()
+            )
+        except requests.exceptions.MissingSchema:
+            logger.warn(
+                'Bad URL request at %s for identifier: %s.' % (source_url, ident)
+            )
+            public_message = 'Bad URL request made for identifier: %s.' % (ident,)
+            raise ResolverException(404, public_message)
 
-            local_fp = join(local_fp, "loris_cache." + format)
+        if response.status_code != 200:
+            public_message = 'Source image not found for identifier: %s. Status code returned: %s' % (ident,response.status_code)
+            log_message = 'Source image not found at %s for identifier: %s. Status code returned: %s' % (source_url,ident,response.status_code)
+            logger.warn(log_message)
+            raise ResolverException(404, public_message)
 
-            try:
-                makedirs(dirname(local_fp))
-            except:
-                logger.debug("Directory already existed... possible problem if not a different format")
+        extension = self.cache_file_extension(ident, response)
+        logger.debug('src extension %s' % (extension,))
 
-            with open(local_fp, 'wb') as fd:
-                for chunk in response.iter_content(2048):
-                    fd.write(chunk)
+        cache_dir = self.cache_dir_path(ident)
+        local_fp = join(cache_dir, "loris_cache." + extension)
 
-            logger.info("Copied %s to %s" % (fp, local_fp))
+        try:
+            makedirs(dirname(local_fp))
+        except:
+            logger.debug("Directory already existed... possible problem if not a different format")
 
-            return (local_fp, format)
+        with open(local_fp, 'wb') as fd:
+            for chunk in response.iter_content(2048):
+                fd.write(chunk)
+
+        logger.info("Copied %s to %s" % (source_url, local_fp))
+
+    def resolve(self, ident):
+        cache_dir = self.cache_dir_path(ident)
+        if not exists(cache_dir):
+            self.copy_to_cache(ident)
+        cached_file_path = self.cached_object(ident)
+        format = self.format_from_ident(cached_file_path, None)
+        logger.debug('src image from local disk: %s' % (cached_file_path,))
+        return (cached_file_path, format)
 
 
 class TemplateHTTPResolver(SimpleHTTPResolver):
@@ -391,11 +436,12 @@ class TemplateHTTPResolver(SimpleHTTPResolver):
         # required for simplehttpresolver
         # all templates are assumed to be uri resolvable
         self.uri_resolvable = True
-                
+
         self.ssl_check = self.config.get('ssl_check', True)
 
     def _web_request_url(self, ident):
-        # only split identifiers that look like template ids; ignore other requests (e.g. favicon)
+        # only split identifiers that look like template ids;
+        # ignore other requests (e.g. favicon)
         if ':' not in ident:
             return
         prefix, ident = ident.split(':', 1)
@@ -422,9 +468,9 @@ class SourceImageCachingResolver(_AbstractResolver):
     Example resolver that one might use if image files were coming from
     mounted network storage. The first call to `resolve()` copies the source
     image into a local cache; subsequent calls use local copy from the cache.
- 
-    The config dictionary MUST contain 
-     * `cache_root`, which is the absolute path to the directory where images 
+
+    The config dictionary MUST contain
+     * `cache_root`, which is the absolute path to the directory where images
         should be cached.
      * `source_root`, the root directory for source images.
     '''
@@ -434,39 +480,50 @@ class SourceImageCachingResolver(_AbstractResolver):
         self.source_root = self.config['source_root']
 
     def is_resolvable(self, ident):
-        ident = unquote(ident)
-        fp = join(self.source_root, ident)
-        return exists(fp)
+        source_fp = self.source_file_path(ident)
+        return exists(source_fp)
 
-    @staticmethod
-    def _format_from_ident(ident):
+    def format_from_ident(self, ident):
         return ident.split('.')[-1]
 
-    def resolve(self, ident):
+    def source_file_path(self, ident):
         ident = unquote(ident)
-        local_fp = join(self.cache_root, ident)
+        return join(self.source_root, ident)
 
-        if exists(local_fp):
-            format = SourceImageCachingResolver._format_from_ident(ident)
-            logger.debug('src image from local disk: %s' % (local_fp,))
-            return (local_fp, format)
-        else:
-            fp = join(self.source_root, ident)
-            logger.debug('src image: %s' % (fp,))
-            if not exists(fp):
-                public_message = 'Source image not found for identifier: %s.' % (ident,)
-                log_message = 'Source image not found at %s for identifier: %s.' % (fp,ident)
-                logger.warn(log_message)
-                raise ResolverException(404, public_message)
+    def cache_file_path(self, ident):
+        ident = unquote(ident)
+        return join(self.cache_root, ident)
 
-            makedirs(dirname(local_fp))
-            copy(fp, local_fp)
-            logger.info("Copied %s to %s" % (fp, local_fp))
+    def in_cache(self, ident):
+        return exists(self.cache_file_path(ident))
 
-            format = SourceImageCachingResolver._format_from_ident(ident)
-            logger.debug('src format %s' % (format,))
+    def copy_to_cache(self, ident):
+        source_fp = self.source_file_path(ident)
+        cache_fp = self.cache_file_path(ident)
 
-            return (local_fp, format)
+        makedirs(dirname(cache_fp))
+        copy(source_fp, cache_fp)
+        logger.info("Copied %s to %s" % (source_fp, cache_fp))
+
+    def raise_404_for_ident(self, ident):
+        source_fp = self.source_file_path(ident)
+        public_message = 'Source image not found for identifier: %s.' % (ident,)
+        log_message = 'Source image not found at %s for identifier: %s.' % (source_fp,ident)
+        logger.warn(log_message)
+        raise ResolverException(404, public_message)
+
+    def resolve(self, ident):
+        if not self.is_resolvable(ident):
+            self.raise_404_for_ident(ident)
+        if not self.in_cache(ident):
+            self.copy_to_cache(ident)
+
+        cache_fp = self.cache_file_path(ident)
+        logger.debug('Image Served from local cache: %s' % (cache_fp,))
+
+        format = self.format_from_ident(ident)
+        logger.debug('Source format %s' % (format,))
+        return (cache_fp, format)
 
 
 

--- a/tests/abstract_resolver.py
+++ b/tests/abstract_resolver.py
@@ -1,3 +1,6 @@
+from loris import loris_exception
+
+
 class AbstractResolverTest(object):
     def test_is_resolvable(self):
         self.assertTrue(
@@ -11,7 +14,7 @@ class AbstractResolverTest(object):
 
     def test_format(self):
         self.assertEqual(
-                self.resolver._format_from_ident(self.identifier),
+                self.resolver.format_from_ident(self.identifier),
                 self.expected_format
         )
 
@@ -19,3 +22,7 @@ class AbstractResolverTest(object):
         expected_resolved = (self.expected_filepath, self.expected_format)
         resolved = self.resolver.resolve(self.identifier)
         self.assertSequenceEqual(resolved, expected_resolved)
+
+    def test_resolve_exception(self):
+        with self.assertRaises(loris_exception.ResolverException):
+            self.resolver.resolve(self.not_identifier)


### PR DESCRIPTION
- Move format_from_ident from a static method into an instance method.  Move format identification logic in ExtensonNormalizingResolver into format_from_ident
- Refactor SourceImageCachingResolver: extract cache logic
- Refactor SimpleHTTPResolver: extract cache logic
- Refactor SimpleHTTPResolver: refactor caching
- Some pep8 reformatting.  Did not touch long lines
- Test to make sure resolver raises exception if asked to resolve something it cannot
- Refactor SimpleFSResolver: Extract method for raising 404 exception if not resolvable.
