### PR TITLE
Allow override of request info per template.

### DIFF
--- a/etc/loris2.conf
+++ b/etc/loris2.conf
@@ -71,15 +71,22 @@ src_img_root = '/usr/local/share/images' # r--
 # [resolver]
 # impl = 'loris.resolver.TemplateHTTPResolver'
 # cache_root='/usr/local/share/images/loris'
-# templates = 'a, b, fedora, devfedora, fedora_obj_ds'
-# a='http://example.edu/images/%s'
-# b='http://example.edu/images-elsewhere/%s'
-# fedora='http://<server>/fedora/objects/%s/datastreams/accessMaster/content'
-# fedora_obj_ds = 'http://<server>/fedora/objects/%s/datastreams/%s/content' # as used with delimiter option below
 ## optional settings
 # delimiter = "|" # optional delimiter for splitting identifier, allowing for n-values to be inserted into the template
 # default_format
 # head_resolvable = False
+# templates = 'a, b, fedora, devfedora, fedora_obj_ds'
+# [[a]]
+# url='http://example.edu/images/%s'
+# [[b]]
+# url='http://example.edu/images-elsewhere/%s'
+## optional overrides for requests using this template
+# user='otheruser'
+# pw='secret'
+# [[fedora]]
+# url='http://<server>/fedora/objects/%s/datastreams/accessMaster/content'
+# [[fedora_obj_ds]]
+# url = 'http://<server>/fedora/objects/%s/datastreams/%s/content' # as used with delimiter option below
 
 [img.ImageCache]
 cache_dp = '/var/cache/loris' # rwx


### PR DESCRIPTION
Changed the return signature of `_web_request_url(ident)` to the tuple of `(url, options)`. This allows the TemplateHTTPResolver to query the prefix-specific subsections of the resolver config for `user`, `pw`, and `ssl_check keys`, and use those values to override the defaults set in the main resolver config.
