### PR TITLE
if a '1,' size parameter would cause the height to be less than 1, se…

### DIFF
--- a/loris/parameters.py
+++ b/loris/parameters.py
@@ -293,8 +293,8 @@ class SizeParameter(object):
                 self.canonical_uri_value = '%d,' % (self.w,)
 
             logger.debug('canonical uri_value for size: %s' % (self.canonical_uri_value,))
-            logger.debug('w %d', self.w)
-            logger.debug('h %d', self.h)
+            logger.debug('w %s', self.w)
+            logger.debug('h %s', self.h)
             if any((dim <= 0 and dim != None) for dim in (self.w, self.h)):
                 msg = 'Width and height must both be positive numbers'
                 raise RequestException(http_status=400, message=msg)
@@ -351,6 +351,15 @@ class SizeParameter(object):
         else:
             self.force_aspect = True
             self.w, self.h = map(int, self.uri_value.split(','))
+
+        if self.h < 1:
+            self.h = 1
+        else:
+            self.h = int(self.h)
+        if self.w < 1:
+            self.w = 1
+        else:
+            self.w = int(self.w)
 
     @staticmethod
     def __mode_from_size_segment(size_segment):

--- a/tests/parameters_t.py
+++ b/tests/parameters_t.py
@@ -222,6 +222,20 @@ class TestSizeParameter(_ParameterTest):
 		self.assertEquals(sp.force_aspect, False)
 		self.assertEquals(sp.mode, PIXEL_MODE)
 		self.assertEquals(sp.canonical_uri_value, '125,')
+                self.assertEquals(type(sp.w), int)
+                self.assertEquals(sp.w, 125)
+                self.assertEquals(type(sp.h), int)
+                self.assertEquals(sp.h, 150)
+
+        def test_tiny_image(self):
+		info = self._get_info_long_x()
+		rp = RegionParameter('full', info)
+		sp = SizeParameter('1,', rp)
+		self.assertEquals(sp.force_aspect, False)
+		self.assertEquals(sp.mode, PIXEL_MODE)
+		self.assertEquals(sp.canonical_uri_value, '1,')
+                self.assertEquals(sp.w, 1)
+                self.assertEquals(sp.h, 1)
 
 	def test_populate_slots_from_h_only(self):
 		# ,h


### PR DESCRIPTION
…t it to 1 instead of letting it go to 0 and cause an error
