### PR TITLE
Fix failing tests (#249)

### DIFF
--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -447,9 +447,10 @@ class TemplateHTTPResolver(SimpleHTTPResolver):
         # only split identifiers that look like template ids;
         # ignore other requests (e.g. favicon)
         if ':' not in ident:
-            return
+            return (None, {})
         prefix, ident = ident.split(':', 1)
 
+        url = None
         if 'delimiter' in self.config:
             # uses delimiter of choice from config file to split identifier
             # into tuple that will be fed to template
@@ -462,7 +463,7 @@ class TemplateHTTPResolver(SimpleHTTPResolver):
         if url is None:
             # if prefix is not recognized, no identifier is returned
             # and loris will return a 404
-            return
+            return (None, {})
         else:
             # first get the generic options
             options = self.request_options()

--- a/tests/resolver_t.py
+++ b/tests/resolver_t.py
@@ -253,9 +253,15 @@ class Test_TemplateHTTPResolver(loris_t.LorisTest):
         config = {
             'cache_root' : self.app.img_cache.cache_root,
             'templates': 'a,b, c, d',
-            'a': 'http://mysite.com/images/%s',
-            'b': 'http://mysite.com/images/%s/access/',
-            'c': 'http://othersite.co/img/%s'
+            'a': {
+                'url': 'http://mysite.com/images/%s'
+            },
+            'b': {
+                'url': 'http://mysite.com/images/%s/access/'
+            },
+            'c': {
+                'url': 'http://othersite.co/img/%s'
+            }
         }
 
         self.app.resolver = TemplateHTTPResolver(config)
@@ -275,13 +281,13 @@ class Test_TemplateHTTPResolver(loris_t.LorisTest):
 
         # test web request uri logic
         self.assertEqual('http://mysite.com/images/foo.jpg',
-            self.app.resolver._web_request_url('a:foo.jpg'))
+            self.app.resolver._web_request_url('a:foo.jpg')[0])
         self.assertEqual('http://mysite.com/images/id1/access/',
-            self.app.resolver._web_request_url('b:id1'))
+            self.app.resolver._web_request_url('b:id1')[0])
         self.assertEqual('http://othersite.co/img/foo:bar:baz',
-            self.app.resolver._web_request_url('c:foo:bar:baz'))
+            self.app.resolver._web_request_url('c:foo:bar:baz')[0])
         self.assertEqual(None,
-            self.app.resolver._web_request_url('unknown:id2'))
+            self.app.resolver._web_request_url('unknown:id2')[0])
 
 
 def suite():


### PR DESCRIPTION
- Correct the config format in resolver_t.py
- Explicitly return a `(None, {})` tuple from the TemplateHTTPResolver if the template or identifier can't be found. This avoids running afoul of "NoneType cannot iterate" errors that were occurring in the tests.