### PR TITLE
Ensure that values the resolver retrieves from its config will be interpolated.

### DIFF
--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -255,8 +255,7 @@ class Loris(object):
     def _load_resolver(self):
         impl = self.app_configs['resolver']['impl']
         ResolverClass = self._import_class(impl)
-        resolver_config =  self.app_configs['resolver'].copy()
-        del resolver_config['impl']
+        resolver_config =  self.app_configs['resolver']
         return ResolverClass(resolver_config)
 
     def _import_class(self, qname):


### PR DESCRIPTION
Previously, the resolver_config was a copy of the app config "resolver" section, which was silently converting the configobj.Section to a plain dictionary. THerefore, calls to get values from keys in that section were not being interpolated. This fix just passes the unaltered "resolver" section to the resolver.