### PR TITLE
Provide support for TIFF files with the extension "tiff"

### DIFF
--- a/doc/resolver.md
+++ b/doc/resolver.md
@@ -11,10 +11,23 @@ impl = 'loris.resolver.SimpleFSResolver'
 src_img_root=/usr/local/share/images
 ```
 
-then `app.resolver.resolve(ident)` will return 
+then `app.resolver.resolve(ident)` will return
 
 ```
 /usr/local/share/images/01/02/0001.jp2
+```
+
+### `ExtensionNormalizingFSResolver`
+
+This supplied implementation extends the SimpleFSResolver, adding an additional "extension map" feature. It allows multiple extensions to be associated with a single file format. If you only need to support "jpg", "tif", and "png" you won't need to use this resolver. If for example you need to support "tiff" and "jpeg" files, you could implement this config::
+
+```ini
+[resolver]
+impl = 'loris.resolver.ExtensionNormalizingFSResolver'
+src_img_root = '/usr/local/share/images'
+  [[extension_map]]
+  jpeg = 'jpg'
+  tiff = 'tif'
 ```
 
 ### `SimpleHTTPResolver`

--- a/etc/loris2.conf
+++ b/etc/loris2.conf
@@ -32,7 +32,7 @@ redirect_canonical_image_request = False
 redirect_id_slash_to_info = True
 
 # max_size_above_full restricts interpolation of images on the server.
-# Default value 200 means that a user cannot request image sizes greater than 
+# Default value 200 means that a user cannot request image sizes greater than
 # 200% of original image size (width or height).
 # Set this value to 100 to disallow interpolation. Set to 0 to remove
 # size restriction.
@@ -58,6 +58,15 @@ format = '%(asctime)s (%(name)s) [%(levelname)s]: %(message)s'
 [resolver]
 impl = 'loris.resolver.SimpleFSResolver'
 src_img_root = '/usr/local/share/images' # r--
+
+#Example of one version of ExtensionNormalizingFSResolver that provides support for jpeg and tiff files
+
+# [resolver]
+# impl = 'loris.resolver.ExtensionNormalizingFSResolver'
+# src_img_root = '/usr/local/share/images' # r--
+#   [[extension_map]]
+#   jpeg = 'jpg'
+#   tiff = 'tif'
 
 #Example of one version of SimpleHTTResolver config
 

--- a/etc/loris2.conf
+++ b/etc/loris2.conf
@@ -32,7 +32,7 @@ redirect_canonical_image_request = False
 redirect_id_slash_to_info = True
 
 # max_size_above_full restricts interpolation of images on the server.
-# Default value 200 means that a user cannot request image sizes greater than
+# Default value 200 means that a user cannot request image sizes greater than 
 # 200% of original image size (width or height).
 # Set this value to 100 to disallow interpolation. Set to 0 to remove
 # size restriction.
@@ -111,9 +111,6 @@ target_formats = ['jpg','png','gif','webp']
 
     [[tif]]
     impl = 'TIF_Transformer'
-
-    [[tiff]]
-        impl = 'TIF_Transformer'
 
     [[png]]
     impl = 'PNG_Transformer'

--- a/etc/loris2.conf
+++ b/etc/loris2.conf
@@ -32,7 +32,7 @@ redirect_canonical_image_request = False
 redirect_id_slash_to_info = True
 
 # max_size_above_full restricts interpolation of images on the server.
-# Default value 200 means that a user cannot request image sizes greater than 
+# Default value 200 means that a user cannot request image sizes greater than
 # 200% of original image size (width or height).
 # Set this value to 100 to disallow interpolation. Set to 0 to remove
 # size restriction.
@@ -111,6 +111,9 @@ target_formats = ['jpg','png','gif','webp']
 
     [[tif]]
     impl = 'TIF_Transformer'
+
+    [[tiff]]
+        impl = 'TIF_Transformer'
 
     [[png]]
     impl = 'PNG_Transformer'

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -93,7 +93,7 @@ class ImageInfo(object):
 
         if src_format == 'jp2':
             new_inst._from_jp2(src_img_fp)
-        elif src_format  in ('jpg','tif','tiff','png'):
+        elif src_format  in ('jpg','tif','png'):
             new_inst._extract_with_pillow(src_img_fp)
         else:
             m = 'Didn\'t get a source format, or at least one we recognize ("%s")' % src_format

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -93,7 +93,7 @@ class ImageInfo(object):
 
         if src_format == 'jp2':
             new_inst._from_jp2(src_img_fp)
-        elif src_format  in ('jpg','tif','png'):
+        elif src_format  in ('jpg','tif','tiff','png'):
             new_inst._extract_with_pillow(src_img_fp)
         else:
             m = 'Didn\'t get a source format, or at least one we recognize ("%s")' % src_format


### PR DESCRIPTION
Running loris on CentOS 7 I was receiving a 500 server error that stated "Didn't get a source format, or at least one we recognize" when accessing files with the extension "tiff". This code change fixed this issue.