### PR TITLE
Missing RGBX color space

### DIFF
--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -36,6 +36,7 @@ PIL_MODES_TO_QUALITIES = {
     'P' : ['default','gray','bitonal'],
     'RGB': ['default','color','gray','bitonal'],
     'RGBA': ['default','color','gray','bitonal'],
+    'RGBX': ['default','color','gray','bitonal'],
     'CMYK': ['default','color','gray','bitonal'],
     'YCbCr': ['default','color','gray','bitonal'],
     'I': ['default','color','gray','bitonal'],


### PR DESCRIPTION
This TIF test image (available at
https://publishing-cdn.elifesciences.org/12997/elife-12997-fig8-figsupp1-v2.tif)
provokes this error:
```
[pid: 28727|app: 0|req: 12/12] 212.44.25.140 () {44 vars in 1100 bytes} [Mon Apr  3 0
8:27:54 2017] GET /lax%3A12997%2Felife-12997-fig8-figsupp1-v2.tif/full/full/0/bitonal
.jpg => generated 0 bytes in 40 msecs (HTTP/1.1 500) 0 headers in 0 bytes (1 switches
 on core 11)
Traceback (most recent call last):
  File "/opt/loris/loris/webapp.py", line 395, in __call__
    return self.wsgi_app(environ, start_response)
  File "/opt/loris/loris/webapp.py", line 346, in wsgi_app
    response = self.route(request)
  File "/opt/loris/loris/webapp.py", line 389, in route
    return self.get_img(request, ident, region, size, rotation, quality, fmt, base_uri)
  File "/opt/loris/loris/webapp.py", line 555, in get_img
    info = self._get_info(ident, request, base_uri, src_fp, src_format)[0]
  File "/opt/loris/loris/webapp.py", line 479, in _get_info
    info = ImageInfo.from_image_file(base_uri, src_fp, src_format, formats, self.max_size_above_full)
  File "/opt/loris/loris/img_info.py", line 97, in from_image_file
    elif src_format  in ('jpg','tif','png'):
  File "/opt/loris/loris/img_info.py", line 136, in _extract_with_pillow
    self.color_profile_bytes = None
KeyError: 'RGBX'
```
but it is fixed by this patch:
https://prod--iiif.elifesciences.org/lax:12997/elife-12997-fig8-figsupp1-v2.tif/full/full/0/default.jpg
https://prod--iiif.elifesciences.org/lax:12997/elife-12997-fig8-figsupp1-v2.tif/full/full/0/color.jpg
https://prod--iiif.elifesciences.org/lax:12997/elife-12997-fig8-figsupp1-v2.tif/full/full/0/gray.jpg
https://prod--iiif.elifesciences.org/lax:12997/elife-12997-fig8-figsupp1-v2.tif/full/full/0/bitonal.jpg