### PR TITLE
src_fp may not be assigned

### DIFF
--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -546,6 +546,7 @@ class Loris(object):
                 r.headers['Link'] = '%s,<%s>;rel="canonical"' % (r.headers['Link'], canonical_uri,)
                 return r
         else:
+            src_fp = None
             try:
 
                 # 1. Resolve the identifier


### PR DESCRIPTION
When `self.resolver` throws a `IOError` or similar, another exception is thrown in the `except` block hiding the original problem:
```
Traceback (most recent call last):
  File "/opt/loris/loris/webapp.py", line 395, in __call__
    return self.wsgi_app(environ, start_response)
  File "/opt/loris/loris/webapp.py", line 346, in wsgi_app
    response = self.route(request)
  File "/opt/loris/loris/webapp.py", line 389, in route
    return self.get_img(request, ident, region, size, rotation, quality, fmt, base_uri)
  File "/opt/loris/loris/webapp.py", line 599, in get_img
    (%s).''' % (str(e),src_fp)
UnboundLocalError: local variable 'src_fp' referenced before assignment
[pid: 1069|app: 0|req: 333/1399] 34.195.252.174 () {40 vars in 796 bytes} [Wed Apr 19 13:29:40 2017] HEAD /lax:2715086876815010635/elife-2715086876815010635-fig2-figsupp1-v1.jpg/full/538,/0/default.jpg => generated 0 bytes in 23110 msecs (HTTP/1.1 500) 0 headers in 0 bytes (0 switches on core 3)
```