### PR TITLE
Fix for issue in debug mode on Debian based systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ dist/
 
 *.swp
 
+*.ropeproject
+
 *.local
 
 rmdirs.sh

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -108,7 +108,7 @@ def read_config(config_file_path):
     # interpolating their values into other keys
     # make a copy of the os.environ dictionary so that the config object can't
     # inadvertently modify the environment
-    config['DEFAULT'] = dict(os.environ)
+    config['DEFAULT'] = {key: val for(key, val) in os.environ.items() if key not in ('PS1')}
     return config
 
 


### PR DESCRIPTION
When running the test suite on my machine (Debian 9; also tried it on Mint), configobj raised an error. A closer investigation showed that the cause was the value of shell environment variable PS1. As PS1 sets the bash prompt and makes no sense for loris, I changed one line in webapp.read_config() to exclude PS1 from beeing added to config['DEFAULT']. After that all tests pass again.