### PR TITLE
Documenting atomic move operations requirement

### DIFF
--- a/etc/loris2.conf
+++ b/etc/loris2.conf
@@ -97,9 +97,11 @@ src_img_root = '/usr/local/share/images' # r--
 # url = 'http://<server>/fedora/objects/%s/datastreams/%s/content' # as used with delimiter option below
 
 [img.ImageCache]
+# must be on the same volume as tmp_dp, for atomic move operations
 cache_dp = '/var/cache/loris' # rwx
 
 [img_info.InfoCache]
+# must be on the same volume as tmp_dp, for atomic move operations
 cache_dp = '/var/cache/loris' # rwx
 
 [transforms]


### PR DESCRIPTION
See https://github.com/loris-imageserver/loris/pull/300 and https://github.com/loris-imageserver/loris/issues/297

This has become a requirement, otherwise the file cannot be atomically moved. I thought I'd document it.