### PR TITLE
Propagating original status code

### DIFF
--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -323,7 +323,7 @@ class SimpleHTTPResolver(_AbstractResolver):
                 public_message = 'Source image not found for identifier: %s. Status code returned: %s' % (ident,response.status_code)
                 log_message = 'Source image not found at %s for identifier: %s. Status code returned: %s' % (source_url,ident,response.status_code)
                 logger.warn(log_message)
-                raise ResolverException(404, public_message)
+                raise ResolverException(response.status_code, public_message)
 
             extension = self.cache_file_extension(ident, response)
             local_fp = join(cache_dir, "loris_cache." + extension)


### PR DESCRIPTION
Proposal to return the original response code in case of failure of an HTTP resolver to retrieve the original image. 404 masks the original response code, which should not be a sensitive information and is very useful for debugging (e.g. 403 is a permission problem, 503 a timeout and so on)

I found no specific reason for sticking to 404 in past Github issues.