### PR TITLE
Switch to consistent use of lazy logging

### DIFF
--- a/loris/img.py
+++ b/loris/img.py
@@ -85,11 +85,11 @@ class ImageRequest(object):
         self.quality = quality
         self.format = target_format
 
-        logger.debug('region slice: %s' % (str(region),))
-        logger.debug('size slice: %s' % (str(size),))
-        logger.debug('rotation slice: %s' % (str(rotation),))
-        logger.debug('quality slice: %s' % (self.quality,))
-        logger.debug('format extension: %s' % (self.format,))
+        logger.debug('region slice: %s', region)
+        logger.debug('size slice: %s', size)
+        logger.debug('rotation slice: %s', rotation)
+        logger.debug('quality slice: %s', self.quality)
+        logger.debug('format extension: %s', self.format)
 
         # These aren't set until we first access them
         self._canonical_cache_path = None
@@ -232,7 +232,7 @@ class ImageCache(dict):
     @staticmethod
     def _link(source, link_name):
         if source == link_name:
-            logger.warn('Circular symlink requested from %s to %s; not creating symlink' % (link_name, source))
+            logger.warn('Circular symlink requested from %s to %s; not creating symlink', link_name, source)
             return
         link_dp = path.dirname(link_name)
         if not path.exists(link_dp):
@@ -240,7 +240,7 @@ class ImageCache(dict):
         if path.lexists(link_name): # shouldn't be the case, but helps debugging
             unlink(link_name)
         symlink(source, link_name)
-        logger.debug('Made symlink from %s to %s' % (link_name, source))
+        logger.debug('Made symlink from %s to %s', link_name, source)
 
     def __setitem__(self, image_request, canonical_fp):
         # Because we're working with files, it's more practical to put derived

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -88,9 +88,9 @@ class ImageInfo(object):
             local_profile['supports'].append('sizeAboveFull')
         new_inst.profile = [ COMPLIANCE, local_profile ]
 
-        logger.debug('Source Format: %s' % (src_format,))
-        logger.debug('Source File Path: %s' % (new_inst.src_img_fp,))
-        logger.debug('Identifier: %s' % (new_inst.ident,))
+        logger.debug('Source Format: %s', src_format)
+        logger.debug('Source File Path: %s', new_inst.src_img_fp)
+        logger.debug('Identifier: %s', new_inst.ident)
 
         if src_format == 'jp2':
             new_inst._from_jp2(src_img_fp)
@@ -153,7 +153,7 @@ class ImageInfo(object):
         if (not initial_bytes[:12] == '\x00\x00\x00\x0cjP  \r\n\x87\n') or \
             (not initial_bytes[16:] == 'ftypjp2 '):
             jp2.close()
-            logger.warning('Invalid JP2 file at %s' % fp)
+            logger.warning('Invalid JP2 file at %s', fp)
             raise ImageInfoException(http_status=500, message='Invalid JP2 file')
 
         #grab width and height
@@ -178,19 +178,19 @@ class ImageInfo(object):
             window.append(c)
 
         colr_meth = struct.unpack('B', jp2.read(1))[0]
-        logger.debug('colr METH: %d' % (colr_meth,))
+        logger.debug('colr METH: %d', colr_meth)
 
         # PREC and APPROX, 1 byte each
         colr_prec = struct.unpack('b', jp2.read(1))[0]
         colr_approx = struct.unpack('B', jp2.read(1))[0]
-        logger.debug('colr PREC: %d' % (colr_prec))
-        logger.debug('colr APPROX: %d' % (colr_approx))
+        logger.debug('colr PREC: %d', colr_prec)
+        logger.debug('colr APPROX: %d', colr_approx)
 
         if colr_meth == 1: # Enumerated Colourspace
             self.color_profile_bytes = None
             enum_cs = int(struct.unpack(">HH", jp2.read(4))[1])
-            logger.debug('Image contains an enumerated colourspace: %d' % (enum_cs,))
-            logger.debug('Enumerated colourspace: %d' % (enum_cs))
+            logger.debug('Image contains an enumerated colourspace: %d', enum_cs)
+            logger.debug('Enumerated colourspace: %d', enum_cs)
             if enum_cs == 16: # sRGB
                 self.profile[1]['qualities'] += ['gray', 'color']
             elif enum_cs == 17: # grayscale
@@ -283,7 +283,7 @@ class ImageInfo(object):
         profile_size_bytes = jp2.read(4)
         profile_size = int(struct.unpack(">I", profile_size_bytes)[0])
 
-        logger.debug('profile size: %d' % (profile_size))
+        logger.debug('profile size: %d', profile_size)
         self.color_profile_bytes = profile_size_bytes + jp2.read(profile_size-4)
 
         # This is an assumption for now (i.e. that if you have a colour profile
@@ -299,7 +299,7 @@ class ImageInfo(object):
         return int(ceil(dim_len * 1.0/scale))
 
     def to_dict(self):
-        logger.debug('self.ident in to_dict: %s' % (self.ident,))
+        logger.debug('self.ident in to_dict: %s', self.ident)
         d = {}
         d['@context'] = CONTEXT
         d['@id'] = self.ident
@@ -401,7 +401,7 @@ class InfoCache(object):
 
                 lastmod = datetime.utcfromtimestamp(os.path.getmtime(info_fp))
                 info_and_lastmod = (info, lastmod)
-                logger.debug('Info for %s read from file system' % (request,))
+                logger.debug('Info for %s read from file system', request)
                 # into mem:
                 self._dict[request.url] = info_and_lastmod
 
@@ -428,13 +428,13 @@ class InfoCache(object):
 
     def __setitem__(self, request, info):
         # to fs
-        logger.debug('request passed to __setitem__: %s' % (request,))
+        logger.debug('request passed to __setitem__: %s', request)
         info_fp = self._get_info_fp(request)
         dp = os.path.dirname(info_fp)
         if not os.path.isdir(dp):
             try:
                 os.makedirs(dp)
-                logger.debug('Created %s' % (dp,))
+                logger.debug('Created %s', dp)
             except OSError as e: # this happens once and a while; not sure why
                 if e.errno == errno.EEXIST:
                     pass
@@ -444,14 +444,14 @@ class InfoCache(object):
         with open(info_fp, 'w') as f:
             f.write(info.to_json())
             f.close()
-            logger.debug('Created %s' % (info_fp,))
+            logger.debug('Created %s', info_fp)
 
         if info.color_profile_bytes:
             icc_fp = self._get_color_profile_fp(request)
             with open(icc_fp, 'wb') as f:
                 f.write(info.color_profile_bytes)
                 f.close()
-                logger.debug('Created %s' % (icc_fp,))
+                logger.debug('Created %s', icc_fp)
 
         # into mem
         lastmod = datetime.utcfromtimestamp(os.path.getmtime(info_fp))

--- a/loris/parameters.py
+++ b/loris/parameters.py
@@ -66,7 +66,7 @@ class RegionParameter(object):
 
         self.mode = RegionParameter._mode_from_region_segment(self.uri_value, self.img_info)
 
-        logger.debug('Region mode is "%s" (from "%s")' % (self.mode,uri_value))
+        logger.debug('Region mode is "%s" (from "%s")', self.mode, uri_value)
 
         if self.mode == FULL_MODE:
             self._populate_slots_for_full()
@@ -78,14 +78,14 @@ class RegionParameter(object):
         else: # self.mode == PCT_MODE:
             self._populate_slots_from_pct()
 
-        logger.debug('decimal_x: %s' % (str(self.decimal_x),))
-        logger.debug('pixel_x: %d' % (self.pixel_x,))
-        logger.debug('decimal_y: %s' % (str(self.decimal_y),))
-        logger.debug('pixel_y: %d' % (self.pixel_y,))
-        logger.debug('decimal_w: %s' % (str(self.decimal_w),))
-        logger.debug('pixel_w: %d' % (self.pixel_w,))
-        logger.debug('decimal_h: %s' % (str(self.decimal_h),))
-        logger.debug('pixel_h: %d' % (self.pixel_h,))
+        logger.debug('decimal_x: %s', self.decimal_x)
+        logger.debug('pixel_x: %d', self.pixel_x)
+        logger.debug('decimal_y: %s', self.decimal_y)
+        logger.debug('pixel_y: %d', self.pixel_y)
+        logger.debug('decimal_w: %s', self.decimal_w)
+        logger.debug('pixel_w: %d', self.pixel_w)
+        logger.debug('decimal_h: %s', self.decimal_h)
+        logger.debug('pixel_h: %d', self.pixel_h)
 
         self._canonicalize()
 
@@ -99,19 +99,19 @@ class RegionParameter(object):
             self.canonical_uri_value = ','.join(map(str, px))
         else:
             self.canonical_uri_value = FULL_MODE
-        logger.debug('canonical uri_value for region %s' % (self.canonical_uri_value,))
+        logger.debug('canonical uri_value for region %s', self.canonical_uri_value)
 
     def _adjust_to_in_bounds(self):
         if (self.decimal_x + self.decimal_w) > DECIMAL_ONE:
             self.decimal_w = DECIMAL_ONE - self.decimal_x
             self.pixel_w = self.img_info.width - self.pixel_x
-            logger.info('decimal_w adjusted to: %s' % (str(self.decimal_w)),)
-            logger.info('pixel_w adjusted to: %d' % (self.pixel_w,))
+            logger.info('decimal_w adjusted to: %s', self.decimal_w)
+            logger.info('pixel_w adjusted to: %d', self.pixel_w)
         if (self.decimal_y + self.decimal_h) > DECIMAL_ONE:
             self.decimal_h = DECIMAL_ONE - self.decimal_y
             self.pixel_h = self.img_info.height - self.pixel_y
-            logger.info('decimal_h adjusted to: %s' % (str(self.decimal_h)),)
-            logger.debug('pixel_h adjusted to: %s' % (str(self.pixel_h)),)
+            logger.info('decimal_h adjusted to: %s', self.decimal_h)
+            logger.debug('pixel_h adjusted to: %s', self.pixel_h)
 
     def _check_for_oob_errors(self):
         if any(axis < 0 for axis in (self.pixel_x, self.pixel_y)):
@@ -271,7 +271,7 @@ class SizeParameter(object):
         '''
         self.uri_value = uri_value
         self.mode = SizeParameter.__mode_from_size_segment(self.uri_value)
-        logger.debug('Size mode is "%s" (from "%s")' % (self.mode,uri_value))
+        logger.debug('Size mode is "%s" (from "%s")', self.mode, uri_value)
 
         if self.mode == FULL_MODE:
             self.force_aspect = False
@@ -292,7 +292,7 @@ class SizeParameter(object):
             else:
                 self.canonical_uri_value = '%d,' % (self.w,)
 
-            logger.debug('canonical uri_value for size: %s' % (self.canonical_uri_value,))
+            logger.debug('canonical uri_value for size: %s', self.canonical_uri_value)
             logger.debug('w %s', self.w)
             logger.debug('h %s', self.h)
             if any((dim <= 0 and dim != None) for dim in (self.w, self.h)):
@@ -433,4 +433,4 @@ class RotationParameter(object):
             raise SyntaxException(http_status=400, message=msg)
 
 
-        logger.debug('canonical rotation is %s' % (self.canonical_uri_value,))
+        logger.debug('canonical rotation is %s', self.canonical_uri_value)

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -104,7 +104,7 @@ class SimpleFSResolver(_AbstractResolver):
             self.raise_404_for_ident(ident)
 
         source_fp = self.source_file_path(ident)
-        logger.debug('src image: %s' % (source_fp,))
+        logger.debug('src image: %s', source_fp)
 
         format_ = self.format_from_ident(ident)
 
@@ -234,9 +234,7 @@ class SimpleHTTPResolver(_AbstractResolver):
         else:
             url = self.source_prefix + ident + self.source_suffix
         if not (url.startswith('http://') or url.startswith('https://')):
-            logger.warn(
-                'Bad URL request at %s for identifier: %s.' % (url, ident)
-            )
+            logger.warn('Bad URL request at %s for identifier: %s.', url, ident)
             public_message = 'Bad URL request made for identifier: %s.' % (ident,)
             raise ResolverException(404, public_message)
         return (url, self.request_options())
@@ -294,8 +292,8 @@ class SimpleHTTPResolver(_AbstractResolver):
             try:
                 extension = self.get_format(ident, constants.FORMATS_BY_MEDIA_TYPE[response.headers['content-type']])
             except KeyError:
-                logger.warn('Your server may be responding with incorrect content-types. Reported %s for ident %s.'
-                            % (response.headers['content-type'], ident))
+                logger.warn('Your server may be responding with incorrect content-types. Reported %s for ident %s.',
+                            response.headers['content-type'], ident)
                 # Attempt without the content-type
                 extension = self.get_format(ident, None)
         else:
@@ -336,11 +334,11 @@ class SimpleHTTPResolver(_AbstractResolver):
             #now rename the tmp file to the desired file name if it still doesn't exist
             #   (another process could have created it)
             if exists(local_fp):
-                logger.info('another process downloaded src image %s' % local_fp)
+                logger.info('another process downloaded src image %s', local_fp)
                 remove(tmp_file.name)
             else:
                 rename(tmp_file.name, local_fp)
-                logger.info("Copied %s to %s" % (source_url, local_fp))
+                logger.info("Copied %s to %s", source_url, local_fp)
 
         return local_fp
 
@@ -399,10 +397,10 @@ class TemplateHTTPResolver(SimpleHTTPResolver):
             name = name.strip()
             cfg = self.config.get(name, None)
             if cfg is None:
-                logger.warn('No configuration specified for resolver template %s' % name)
+                logger.warn('No configuration specified for resolver template %s', name)
             else:
                 self.templates[name] = cfg
-        logger.debug('TemplateHTTPResolver templates: %s' % str(self.templates))
+        logger.debug('TemplateHTTPResolver templates: %s', self.templates)
 
     def _web_request_url(self, ident):
         # only split identifiers that look like template ids;
@@ -476,7 +474,7 @@ class SourceImageCachingResolver(_AbstractResolver):
 
         makedirs(dirname(cache_fp))
         copy(source_fp, cache_fp)
-        logger.info("Copied %s to %s" % (source_fp, cache_fp))
+        logger.info("Copied %s to %s", source_fp, cache_fp)
 
     def raise_404_for_ident(self, ident):
         source_fp = self.source_file_path(ident)
@@ -492,7 +490,7 @@ class SourceImageCachingResolver(_AbstractResolver):
             self.copy_to_cache(ident)
 
         cache_fp = self.cache_file_path(ident)
-        logger.debug('Image Served from local cache: %s' % (cache_fp,))
+        logger.debug('Image Served from local cache: %s', cache_fp)
 
         format_ = self.format_from_ident(ident)
         return (cache_fp, format_)

--- a/loris/transforms.py
+++ b/loris/transforms.py
@@ -28,7 +28,7 @@ class _AbstractTransformer(object):
         self.config = config
         self.target_formats = config['target_formats']
         self.dither_bitonal_images = config['dither_bitonal_images']
-        logger.debug('Initialized %s.%s' % (__name__, self.__class__.__name__))
+        logger.debug('Initialized %s.%s', __name__, self.__class__.__name__)
 
     def transform(self, src_fp, target_fp, image_request):
         '''
@@ -68,13 +68,13 @@ class _AbstractTransformer(object):
                 image_request.region_param.pixel_x+image_request.region_param.pixel_w,
                 image_request.region_param.pixel_y+image_request.region_param.pixel_h
             )
-            logger.debug('cropping to: %s' % (repr(box),))
+            logger.debug('cropping to: %r', box)
             im = im.crop(box)
 
         # resize
         if image_request.size_param.canonical_uri_value != 'full':
             wh = [int(image_request.size_param.w),int(image_request.size_param.h)]
-            logger.debug('Resizing to: %s' % (repr(wh),) )
+            logger.debug('Resizing to: %r', wh)
             im = im.resize(wh, resample=Image.ANTIALIAS)
 
 
@@ -88,7 +88,7 @@ class _AbstractTransformer(object):
             # transparent background (A == Alpha layer)
             if float(image_request.rotation_param.rotation) % 90 != 0.0 and \
                 image_request.format == 'png':
-                
+
                 if image_request.quality in ('gray', 'bitonal'):
                     im = im.convert('LA')
                 else:
@@ -123,7 +123,7 @@ class _AbstractTransformer(object):
         elif image_request.format == 'webp':
             # see http://pillow.readthedocs.org/en/latest/handbook/image-file-formats.html#webp
             im.save(target_fp, quality=90)
-         
+
 
 class _PillowTransformer(_AbstractTransformer):
     def __init__(self, config):
@@ -259,7 +259,7 @@ class OPJ_JP2Transformer(_AbstractJP2Transformer):
             x1 = region_param.pixel_x + region_param.pixel_w
             y1 = region_param.pixel_y + region_param.pixel_h
             arg = ','.join(map(str, (x0, y0, x1, y1)))
-        logger.debug('opj region parameter: %s' % (arg,))
+        logger.debug('opj region parameter: %s', arg)
         return arg
 
     def transform(self, src_fp, target_fp, image_request):
@@ -268,7 +268,7 @@ class OPJ_JP2Transformer(_AbstractJP2Transformer):
 
         # make the named pipe
         mkfifo_call = '%s %s' % (self.mkfifo, fifo_fp)
-        logger.debug('Calling %s' % (mkfifo_call,))
+        logger.debug('Calling %s', mkfifo_call)
         resp = subprocess.check_call(mkfifo_call, shell=True)
         if resp != 0:
             logger.error('Problem with mkfifo')
@@ -284,7 +284,7 @@ class OPJ_JP2Transformer(_AbstractJP2Transformer):
 
         opj_cmd = ' '.join((self.opj_decompress,i,reg,red,o))
 
-        logger.debug('Calling: %s' % (opj_cmd,))
+        logger.debug('Calling: %s', opj_cmd)
 
         # Start the shellout. Blocks until the pipe is empty
         with open(devnull, 'w') as fnull:
@@ -292,7 +292,7 @@ class OPJ_JP2Transformer(_AbstractJP2Transformer):
                 stderr=fnull, stdout=fnull, env=self.env)
 
         f = open(fifo_fp, 'rb')
-        logger.debug('Opened %s' % fifo_fp)
+        logger.debug('Opened %s', fifo_fp)
 
         # read from the named pipe
         p = Parser()
@@ -372,7 +372,7 @@ class KakaduJP2Transformer(_AbstractJP2Transformer):
             width = region_param.decimal_w
 
             arg = '\{%s,%s\},\{%s,%s\}' % (top, left, height, width)
-        logger.debug('kdu region parameter: %s' % (arg,))
+        logger.debug('kdu region parameter: %s', arg)
         return arg
 
     def _run_transform(self, target_fp, image_request, kdu_cmd, fifo_fp):
@@ -424,7 +424,7 @@ class KakaduJP2Transformer(_AbstractJP2Transformer):
         process.start()
         process.join(self.transform_timeout)
         if process.is_alive():
-            logger.info('terminating process for %s, %s' % (src_fp, target_fp))
+            logger.info('terminating process for %s, %s', src_fp, target_fp)
             process.terminate()
             if path.exists(fifo_fp):
                 unlink(fifo_fp)

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -283,7 +283,7 @@ class Loris(object):
         self.app_configs = app_configs
         self.logger = _configure_logging(app_configs['logging'])
         self.logger.debug('Loris initialized with these settings:')
-        [self.logger.debug('%s.%s=%s' % (key, sub_key, self.app_configs[key][sub_key]))
+        [self.logger.debug('%s.%s=%s', key, sub_key, self.app_configs[key][sub_key])
             for key in self.app_configs for sub_key in self.app_configs[key]]
 
         # make the loris.Loris configs attrs for easier access
@@ -310,9 +310,9 @@ class Loris(object):
     def _load_transformers(self):
         tforms = self.app_configs['transforms']
         source_formats = [k for k in tforms if isinstance(tforms[k], dict)]
-        self.logger.debug('Source formats: %s' % (repr(source_formats),))
+        self.logger.debug('Source formats: %r', source_formats)
         global_tranform_options = dict((k, v) for k, v in tforms.iteritems() if not isinstance(v, dict))
-        self.logger.debug('Global transform options: %s' % (repr(global_tranform_options),))
+        self.logger.debug('Global transform options: %r', global_tranform_options)
 
         transformers = {}
         for sf in source_formats:
@@ -324,7 +324,7 @@ class Loris(object):
     def _load_transformer(self, config):
         Klass = getattr(transforms, config['impl'])
         instance = Klass(config)
-        self.logger.debug('Loaded Transformer %s' % (config['impl'],))
+        self.logger.debug('Loaded Transformer %s', config['impl'])
         return instance
 
     def _load_resolver(self):
@@ -339,7 +339,7 @@ class Loris(object):
         module_name = '.'.join(qname.split('.')[:-1])
         class_name = qname.split('.')[-1]
         module = __import__(module_name, fromlist=[class_name])
-        self.logger.debug('Imported %s' % (qname,))
+        self.logger.debug('Imported %s', qname)
         return getattr(module, class_name)
 
     def wsgi_app(self, environ, start_response):
@@ -433,7 +433,7 @@ class Loris(object):
         last_mod = parse_date(http_date(last_mod)) # see note under get_img
 
         if ims and ims >= last_mod:
-            self.logger.debug('Sent 304 for %s ' % (ident,))
+            self.logger.debug('Sent 304 for %s ', ident)
             r.status_code = 304
         else:
             if last_mod:
@@ -471,17 +471,17 @@ class Loris(object):
             except KeyError:
                 raise ImageInfoException(500, 'unknown source format')
 
-            self.logger.debug('Format: %s' % (src_format,))
-            self.logger.debug('File Path: %s' % (src_fp,))
-            self.logger.debug('Identifier: %s' % (ident,))
-            self.logger.debug('Base URI: %s' % (base_uri,))
+            self.logger.debug('Format: %s', src_format)
+            self.logger.debug('File Path: %s', src_fp)
+            self.logger.debug('Identifier: %s', ident)
+            self.logger.debug('Base URI: %s', base_uri)
 
             # get the info
             info = ImageInfo.from_image_file(base_uri, src_fp, src_format, formats, self.max_size_above_full)
 
             # store
             if self.enable_caching:
-                self.logger.debug('ident used to store %s: %s' % (ident,ident))
+                self.logger.debug('ident used to store %s: %s', ident, ident)
                 self.info_cache[request] = info
                 # pick up the timestamp... :()
                 info,last_mod = self.info_cache[request]
@@ -508,7 +508,7 @@ class Loris(object):
         image_request = img.ImageRequest(ident, region, size, rotation,
                                          quality, target_fmt)
 
-        self.logger.debug('Image Request Path: %s' % (image_request.request_path,))
+        self.logger.debug('Image Request Path: %s', image_request.request_path)
 
         if self.enable_caching:
             in_cache = image_request in self.img_cache
@@ -522,11 +522,11 @@ class Loris(object):
             # as when went sent it, so for an accurate comparison turn it into
             # an http date and then parse it again :-( :
             img_last_mod = parse_date(http_date(img_last_mod))
-            self.logger.debug("Time from FS (default, rounded): " + str(img_last_mod))
-            self.logger.debug("Time from IMS Header (parsed): " + str(parse_date(ims_hdr)))
+            self.logger.debug("Time from FS (default, rounded): %s", img_last_mod)
+            self.logger.debug("Time from IMS Header (parsed): %s", parse_date(ims_hdr))
             # ims_hdr = parse_date(ims_hdr) # catch parsing errors?
             if ims_hdr and parse_date(ims_hdr) >= img_last_mod:
-                self.logger.debug('Sent 304 for %s ' % (fp,))
+                self.logger.debug('Sent 304 for %s ', fp)
                 r.status_code = 304
                 return r
             else:
@@ -568,7 +568,7 @@ class Loris(object):
                 # 5. Redirect if appropriate
                 if self.redirect_canonical_image_request:
                     if not image_request.is_canonical:
-                        self.logger.debug('Attempting redirect to %s' % (image_request.canonical_request_path,))
+                        self.logger.debug('Attempting redirect to %s', image_request.canonical_request_path,)
                         r.headers['Location'] = image_request.canonical_request_path
                         r.status_code = 301
                         return r

--- a/tests/loris_t.py
+++ b/tests/loris_t.py
@@ -137,9 +137,9 @@ class LorisTest(unittest.TestCase):
                     p = path.join(dp, node)
                     if path.isdir(p):
                         rmtree(p)
-                        logger.debug('Removed %s' % (p,))
+                        logger.debug('Removed %s', p)
                     else: # TODO: make sure this covers symlinks
                         unlink(p)
-                        logger.debug('Removed %s' % (p,))
+                        logger.debug('Removed %s', p)
                 rmtree(dp)
-                logger.debug('Removed %s' % (dp,))
+                logger.debug('Removed %s', dp)


### PR DESCRIPTION
This means that the string substitution only occurs if the string is being logged everywhere – this reduces the perf impact of debug logging when it’s not turned on.