### PR TITLE
Fix an undefined variable error

### DIFF
--- a/loris/transforms.py
+++ b/loris/transforms.py
@@ -37,7 +37,7 @@ class _AbstractTransformer(object):
             target_fp (str)
             image (ImageRequest)
         '''
-        e = self.__class__.__name__
+        cn = self.__class__.__name__
         raise NotImplementedError('transform() not implemented for %s' % (cn,))
 
     def _derive_with_pil(self, im, target_fp, image_request, rotate=True, crop=True):

--- a/tests/transforms_t.py
+++ b/tests/transforms_t.py
@@ -17,6 +17,23 @@ from the `/loris` (not `/loris/loris`) directory.
 """
 
 
+class Test_AbstractTransformer(unittest.TestCase):
+
+    def test_missing_transform_raises_not_implemented_error(self):
+        class ExampleTransformer(transforms._AbstractTransformer):
+            pass
+
+        e = ExampleTransformer(config={
+            'target_formats': [],
+            'dither_bitonal_images': '',
+        })
+        with self.assertRaises(NotImplementedError) as cm:
+            e.transform(src_fp=None, target_fp=None, image_request=None)
+        self.assertEqual(
+            cm.exception.message,
+            'transform() not implemented for ExampleTransformer')
+
+
 class UnitTest_KakaduJP2Transformer(unittest.TestCase):
 
     def test_init(self):
@@ -103,6 +120,7 @@ class Test_PILTransformer(loris_t.LorisTest):
 
 def suite():
     test_suites = []
+    test_suites.append(unittest.makeSuite(Test_AbstractTransformer, 'test'))
     test_suites.append(unittest.makeSuite(UnitTest_KakaduJP2Transformer, 'test'))
     test_suites.append(unittest.makeSuite(Test_KakaduJP2Transformer, 'test'))
     test_suites.append(unittest.makeSuite(Test_PILTransformer, 'test'))


### PR DESCRIPTION
And adds a test for the function in question, which highlights the original error and prevents future regressions.