### PR TITLE
Improvements to the RotationParameter class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ xb526qv4524_05_0001.jp2
 /python*
 
 todo.md
+
+.hypothesis

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ python:
 
 install:
  - pip install -r requirements.txt
+ - pip install -r requirements_test.txt
 
 script: "python test.py"
 

--- a/doc/develop.md
+++ b/doc/develop.md
@@ -36,7 +36,13 @@ __N.B.:__ When developing or extending, i.e., instantiating the application inst
 
 Running Tests
 -------------
-To run all of the tests, from the `/loris` directory (not `/loris/loris`) just run `./test.py`. If you just want to run the tests for a single module, do, e.g. `python -m unittest -v tests.parameters_t` from the same dir as above.
+To run all of the tests, you need to install test dependencies:
+
+```console
+$ pip install -r requirements_test.txt
+```
+
+Then run `./test.py` from the `/loris` directory (not `/loris/loris`). If you just want to run the tests for a single module, do, e.g. `python -m unittest -v tests.parameters_t` from the same dir as above.
 
 Using the Development Server
 ----------------------------

--- a/loris/parameters.py
+++ b/loris/parameters.py
@@ -393,6 +393,7 @@ class SizeParameter(object):
     def __str__(self):
         return self.uri_value
 
+
 class RotationParameter(object):
     '''Internal representation of the rotation slice of an IIIF image URI.
 
@@ -423,7 +424,7 @@ class RotationParameter(object):
         '''
 
         if not RotationParameter.ROTATION_REGEX.match(uri_value):
-            msg = 'Rotation "%s" is not a number'  % (uri_value,)
+            msg = 'Rotation parameter %r is not a number' % (uri_value,)
             raise SyntaxException(http_status=400, message=msg)
 
         if uri_value[0] == '!':
@@ -443,8 +444,7 @@ class RotationParameter(object):
             self.canonical_uri_value = '!%s' % self.canonical_uri_value
 
         if not 0.0 <= float(self.rotation) <= 360.0:
-            msg = 'Rotation argument "%s" is not between 0 and 360' % (uri_value,)
+            msg = 'Rotation parameter %r is not between 0 and 360' % (uri_value,)
             raise SyntaxException(http_status=400, message=msg)
 
-
-        logger.debug('canonical rotation is %s', self.canonical_uri_value)
+        logger.debug('Canonical rotation parameter is %s', self.canonical_uri_value)

--- a/loris/parameters.py
+++ b/loris/parameters.py
@@ -396,23 +396,30 @@ class SizeParameter(object):
 class RotationParameter(object):
     '''Internal representation of the rotation slice of an IIIF image URI.
 
+    See http://iiif.io/api/image/2.0/#rotation:
+
+       The rotation parameter specifies mirroring and rotation. A leading
+       exclamation mark ("!") indicates that the image should be mirrored by
+       reflection on the vertical axis before any rotation is applied.
+       The numerical value represents the number of degrees of clockwise
+       rotation, and may be any floating point number from 0 to 360.
+
     Slots:
-        uri_value (str)
         canonical_uri_value (str)
-        mirror (str)
+        mirror (bool)
         rotation (str)
     '''
     ROTATION_REGEX = re.compile('^!?[\d.]+$')
 
-    __slots__ = ('uri_value','canonical_uri_value','mirror','rotation')
+    __slots__ = ('canonical_uri_value', 'mirror', 'rotation')
 
     def __init__(self, uri_value):
-        '''Take the uri value and round it to the nearest 90.
+        '''Take the uri value, and parse out mirror and rotation values.
         Args:
             uri_value (str): the rotation slice of the request URI.
         Raises:
             SyntaxException:
-                If the argument is not a digit, is < 0, or > 360
+                If the argument is not a valid rotation slice.
         '''
 
         if not RotationParameter.ROTATION_REGEX.match(uri_value):

--- a/loris/parameters.py
+++ b/loris/parameters.py
@@ -410,7 +410,7 @@ class RotationParameter(object):
         mirror (bool)
         rotation (str)
     '''
-    ROTATION_REGEX = re.compile(r'^(?P<mirror>!?)(?P<rotation>[\d.])+$')
+    ROTATION_REGEX = re.compile(r'^(?P<mirror>!?)(?P<rotation>[\d.]+)$')
 
     __slots__ = ('canonical_uri_value', 'mirror', 'rotation')
 

--- a/loris/parameters.py
+++ b/loris/parameters.py
@@ -429,11 +429,18 @@ class RotationParameter(object):
         if uri_value[0] == '!':
             self.mirror = True
             self.rotation = uri_value[1:]
-            self.canonical_uri_value = '!%g' % (float(uri_value[1:]),)
         else:
             self.mirror = False
             self.rotation = uri_value
-            self.canonical_uri_value = '%g' % (float(uri_value),)
+
+        try:
+            self.canonical_uri_value = '%g' % (float(self.rotation),)
+        except ValueError:
+            msg = 'Rotation parameter %r is not a floating point number' % (uri_value,)
+            raise SyntaxException(http_status=400, message=msg)
+
+        if self.mirror:
+            self.canonical_uri_value = '!%s' % self.canonical_uri_value
 
         if not 0.0 <= float(self.rotation) <= 360.0:
             msg = 'Rotation argument "%s" is not between 0 and 360' % (uri_value,)

--- a/loris/parameters.py
+++ b/loris/parameters.py
@@ -410,7 +410,7 @@ class RotationParameter(object):
         mirror (bool)
         rotation (str)
     '''
-    ROTATION_REGEX = re.compile('^!?[\d.]+$')
+    ROTATION_REGEX = re.compile(r'^(?P<mirror>!?)(?P<rotation>[\d.])+$')
 
     __slots__ = ('canonical_uri_value', 'mirror', 'rotation')
 
@@ -423,16 +423,14 @@ class RotationParameter(object):
                 If the argument is not a valid rotation slice.
         '''
 
-        if not RotationParameter.ROTATION_REGEX.match(uri_value):
+        match = RotationParameter.ROTATION_REGEX.match(uri_value)
+
+        if not match:
             msg = 'Rotation parameter %r is not a number' % (uri_value,)
             raise SyntaxException(http_status=400, message=msg)
 
-        if uri_value[0] == '!':
-            self.mirror = True
-            self.rotation = uri_value[1:]
-        else:
-            self.mirror = False
-            self.rotation = uri_value
+        self.mirror = bool(match.group('mirror'))
+        self.rotation = match.group('rotation')
 
         try:
             self.canonical_uri_value = '%g' % (float(self.rotation),)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ ordereddict
 requests >= 2.12.0
 mock == 1.0.1
 responses == 0.3.0
-hypothesis >= 3.11.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ ordereddict
 requests >= 2.12.0
 mock == 1.0.1
 responses == 0.3.0
+hypothesis >= 3.11.6

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,1 @@
+hypothesis >= 3.11.6

--- a/tests/parameters_t.py
+++ b/tests/parameters_t.py
@@ -395,6 +395,14 @@ class TestRotationParameter(_ParameterTest):
 			rp = RotationParameter('!361')
 		with self.assertRaises(SyntaxException):
 			rp = RotationParameter('-0.1')
+		with self.assertRaises(SyntaxException):
+			rp = RotationParameter('1.3.6')
+		with self.assertRaises(SyntaxException):
+			rp = RotationParameter('!2.7.13')
+		with self.assertRaises(SyntaxException):
+			rp = RotationParameter('.')
+		with self.assertRaises(SyntaxException):
+			rp = RotationParameter('.0.')
 
 	def test_uri_value(self):
 		rp = RotationParameter('0')

--- a/tests/parameters_t.py
+++ b/tests/parameters_t.py
@@ -14,6 +14,9 @@ from loris.parameters import RotationParameter
 from loris.parameters import SizeParameter
 import loris_t
 
+from hypothesis import given
+from hypothesis.strategies import text
+
 """
 Parameter object tests. To run this test on its own, do:
 
@@ -403,6 +406,13 @@ class TestRotationParameter(_ParameterTest):
 			rp = RotationParameter('.')
 		with self.assertRaises(SyntaxException):
 			rp = RotationParameter('.0.')
+
+	@given(text(alphabet='0123456789.!'))
+	def test_parsing_parameter_either_passes_or_is_syntaxexception(self, xs):
+	    try:
+	        RotationParameter(xs)
+	    except SyntaxException:
+	        pass
 
 	def test_uri_value(self):
 		rp = RotationParameter('0')


### PR DESCRIPTION
This is a second attempt at #310, which GitHub isn’t letting me update with review markups/merge conflicts. 😢

Notes from the description on that PR:

> I was reading the code for the `RotationParameter`, and spotted a bug: if you pass it a non-float value that includes `.[0-9]` like `.` or `2.7.13` or `.0.`, it throws a ValueError instead of a SyntaxException. This patch changes it to always throw a SyntaxException, along with tests for a few of the bad values I found.
>
> Additionally:
>
> * Some fixes to the docstring and slots, which were quite out-of-date.
> * I’ve added a test using [Hypothesis](http://hypothesis.readthedocs.io/en/latest/) *(disclaimer: I’m a maintainer)*, which fuzzes `RotationParameter` to try to find a string that causes it to throw something other than a SyntaxException. This was how I discovered the original bug. Happy to remove this if you don’t want the additional test dependency.