### PR TITLE
Fix some typos in documentation and code comments

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -62,7 +62,7 @@ map_embedded_profile_to_srgb=True
 srgb_profile_fp=/usr/share/color/icc/colord/sRGB.icc
 ```
 
-Then Loris will, as the name of the option suggests, map the color profile that is embedded in the JP2 to sRGB. To faciliate this, the Python Imaging Library has to be installed with [Little CMS](http://www.littlecms.com/) support. Instructions on how to do this are on the [Configuration page](configuration.md).
+Then Loris will, as the name of the option suggests, map the color profile that is embedded in the JP2 to sRGB. To facilitate this, the Python Imaging Library has to be installed with [Little CMS](http://www.littlecms.com/) support. Instructions on how to do this are on the [Configuration page](configuration.md).
 
 * * *
 

--- a/doc/two_lorises.md
+++ b/doc/two_lorises.md
@@ -2,7 +2,7 @@
 
 See https://code.google.com/p/modwsgi/wiki/VirtualEnvironments
 
-This assumes you'll create virtual enviroment in a user's home directory, and
+This assumes you'll create virtual environment in a user's home directory, and
 use those environments to store the different dependencies for each version.
 
 The system Python is still used to run WSGI, though it may be possible to use 

--- a/etc/pylint.rc
+++ b/etc/pylint.rc
@@ -2,7 +2,7 @@
 
 # lint Python modules using external checkers.
 # 
-# This is the main checker controling the other ones and the reports
+# This is the main checker controlling the other ones and the reports
 # generation. It is itself both a raw checker and an astng checker in order
 # to:
 # * handle message activation / deactivation at the module level
@@ -73,7 +73,7 @@ reports=yes
 
 # Python expression which should return a note less than 10 (10 is the highest
 # note).You have access to the variables errors warning, statement which
-# respectivly contain the number of errors / warnings messages and the total
+# respectively contain the number of errors / warnings messages and the total
 # number of statements analyzed. This is used by the global evaluation report
 # (R0004).
 evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
@@ -116,7 +116,7 @@ additional-builtins=
 ignore-mixin-members=yes
 
 # List of classes names for which member attributes should not be checked
-# (useful for classes with attributes dynamicaly set).
+# (useful for classes with attributes dynamically set).
 ignored-classes=SQLObject
 
 # List of members which are usually get through zope's acquisition mecanism and
@@ -243,7 +243,7 @@ int-import-graph=
 # checks for :
 # * methods without self as first argument
 # * overridden methods signature
-# * access only to existant members via self
+# * access only to existent members via self
 # * attributes not defined in the __init__ method
 # * supported interfaces implementation
 # * unreachable code

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -143,7 +143,7 @@ class SimpleHTTPResolver(_AbstractResolver):
      * `ssl_check`, whether to check the validity of the origin server's HTTPS
      certificate. Set to False if you are using an origin server with a
      self-signed certificate.
-     * `cert`, path to an SSL client certificate to use for authentication. If `cert` and `key` are both present, they take precedence over `user` and `pw` for authetication.
+     * `cert`, path to an SSL client certificate to use for authentication. If `cert` and `key` are both present, they take precedence over `user` and `pw` for authentication.
      * `key`, path to an SSL client key to use for authentication.
     '''
     def __init__(self, config):

--- a/loris/transforms.py
+++ b/loris/transforms.py
@@ -52,7 +52,7 @@ class _AbstractTransformer(object):
                 True by default; can be set to False in case the rotation was
                 done further upstream.
             crop (bool):
-                True by default; can be set to False when the region was aleady
+                True by default; can be set to False when the region was already
                 extracted further upstream.
         Returns:
             void (puts an image at target_fp)

--- a/setup.py
+++ b/setup.py
@@ -275,7 +275,7 @@ setup(
 #   (e.g. `crontab -e -u %(user_n)s`).
 
 #  3. Have a look at the WSGI file in %(www_dp)s. It should be fine as-is, but
-#   there's always a chance that it isn't. The first thing to try is explictly
+#   there's always a chance that it isn't. The first thing to try is explicitly
 #   adding the package to your PYTHONPATH (see commented code).
 
 #  4. Configure Apache (see doc/apache.md).

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -334,7 +334,7 @@ class InfoCache(loris_t.LorisTest):
 
     def test_info_goes_to_http_fs_cache(self):
         # there isn't a way to do a fake HTTPS request, but this at least
-        # confirms that HTTP goes to ther right place.
+        # confirms that HTTP goes to the right place.
         request_uri = '/%s/%s' % (self.test_jp2_color_id,'info.json')
         resp = self.client.get(request_uri)
         expected_path = path.join(


### PR DESCRIPTION
Most of them were found by codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>