### PR TITLE
Slightly better exception handling

### DIFF
--- a/loris/img.py
+++ b/loris/img.py
@@ -8,8 +8,6 @@ from os import path, symlink, makedirs, unlink, error as os_error, rename
 from parameters import RegionParameter
 from parameters import RotationParameter
 from parameters import SizeParameter
-from loris_exception import RequestException
-from loris_exception import SyntaxException
 from loris_exception import ImageException
 from urllib import unquote, quote_plus
 from urllib import unquote
@@ -109,28 +107,19 @@ class ImageRequest(object):
     @property
     def region_param(self):
         if self._region_param is None:
-            try:
-                self._region_param = RegionParameter(self.region_value, self.info)
-            except (SyntaxException,RequestException):
-                raise
+            self._region_param = RegionParameter(self.region_value, self.info)
         return self._region_param
 
     @property
     def size_param(self):
         if self._size_param is None:
-            try:
-                self._size_param = SizeParameter(self.size_value, self.region_param)
-            except (RequestException,SyntaxException):
-                raise
+            self._size_param = SizeParameter(self.size_value, self.region_param)
         return self._size_param
 
     @property
     def rotation_param(self):
         if self._rotation_param is None:
-            try:
-                self._rotation_param = RotationParameter(self.rotation_value)
-            except (RotationParameter,SyntaxException):
-                raise
+            self._rotation_param = RotationParameter(self.rotation_value)
         return self._rotation_param
 
     @property
@@ -224,7 +213,7 @@ class ImageCache(dict):
     def __getitem__(self, image_request):
         fp = self.get(image_request)
         if fp is None:
-            raise KeyError
+            raise KeyError(image_request)
         return fp
 
     @staticmethod

--- a/loris/parameters.py
+++ b/loris/parameters.py
@@ -279,13 +279,10 @@ class SizeParameter(object):
             self.h = region_parameter.pixel_h
             self.canonical_uri_value = FULL_MODE
         else:
-            try:
-                if self.mode == PCT_MODE:
-                    self._populate_slots_from_pct(region_parameter)
-                else: # self.mode == PIXEL_MODE:
-                    self._populate_slots_from_pixels(region_parameter)
-            except (SyntaxException, RequestException):
-                raise
+            if self.mode == PCT_MODE:
+                self._populate_slots_from_pct(region_parameter)
+            else: # self.mode == PIXEL_MODE:
+                self._populate_slots_from_pixels(region_parameter)
 
             if self.force_aspect:
                 self.canonical_uri_value = '%d,%d' % (self.w,self.h)


### PR DESCRIPTION
* Make sure KeyError includes the value that caused the error
* A `try … catch` block that just re-raises the error can be dropped with no effect