### PR TITLE
Add a test and bugfix for InfoCache

### DIFF
--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -453,7 +453,7 @@ class InfoCache(object):
         info_fp = self._get_info_fp(request)
         os.unlink(info_fp)
 
-        icc_fp = self._getcolor_profile_bytes(request)
+        icc_fp = self._get_color_profile_fp(request)
         if os.path.exists(icc_fp):
             os.unlink(icc_fp)
 

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -448,7 +448,7 @@ class InfoCache(object):
 
     def __delitem__(self, request):
         with self._lock:
-            del self._dict[request]
+            del self._dict[request.url]
 
         info_fp = self._get_info_fp(request)
         os.unlink(info_fp)

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -10,6 +10,9 @@ from werkzeug.datastructures import Headers
 import json
 import loris_t
 
+from werkzeug.test import EnvironBuilder
+from werkzeug.wrappers import Request
+
 
 """
 Info unit and function tests. To run this test on its own, do:
@@ -343,6 +346,27 @@ class InfoCache(loris_t.LorisTest):
             'info.json'
         )
         self.assertTrue(path.exists(expected_path))
+
+    def test_can_delete_items_from_infocache(self):
+        '''
+        Test for InfoCache.__delitem__.
+        '''
+        cache = img_info.InfoCache(root=self.SRC_IMAGE_CACHE)
+
+        path = self.test_jp2_color_fp
+        builder = EnvironBuilder(path=path)
+        env = builder.get_environ()
+        req = Request(env)
+
+        info = img_info.ImageInfo.from_image_file(
+            uri=self.test_jp2_color_uri,
+            src_img_fp=self.test_jp2_color_fp,
+            src_format=self.test_jp2_color_fmt
+        )
+
+        cache[req] = info
+        del cache[req]
+
 
 def suite():
     import unittest

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -10,9 +10,6 @@ from werkzeug.datastructures import Headers
 import json
 import loris_t
 
-from werkzeug.test import EnvironBuilder
-from werkzeug.wrappers import Request
-
 import webapp_t
 
 

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -13,6 +13,8 @@ import loris_t
 from werkzeug.test import EnvironBuilder
 from werkzeug.wrappers import Request
 
+import webapp_t
+
 
 """
 Info unit and function tests. To run this test on its own, do:
@@ -354,9 +356,7 @@ class InfoCache(loris_t.LorisTest):
         cache = img_info.InfoCache(root=self.SRC_IMAGE_CACHE)
 
         path = self.test_jp2_color_fp
-        builder = EnvironBuilder(path=path)
-        env = builder.get_environ()
-        req = Request(env)
+        req = webapp_t._get_werkzeug_request(path=path)
 
         info = img_info.ImageInfo.from_image_file(
             uri=self.test_jp2_color_uri,


### PR DESCRIPTION
Linting spotted that `_get_color_profile_fp` isn’t a defined method on InfoCache. I wrote a test for the `__delitem__` method that would expose the bug.

Along the way, I uncovered a second bug in that method, and made a small simplification in `webapp_t.py`.