### PR TITLE
Start collecting coverage data in CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+branch = True
+include =
+    loris/*.py
+
+[report]
+show_missing = True

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ xb526qv4524_05_0001.jp2
 todo.md
 
 .hypothesis
+
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,9 @@ install:
  - pip install -r requirements.txt
  - pip install -r requirements_test.txt
 
-script: "python test.py"
+script:
+  - "coverage run ./test.py"
+  - "coverage report"
 
 notifications:
   email:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,1 +1,2 @@
+coverage==4.4.1
 hypothesis >= 3.11.6


### PR DESCRIPTION
I am 💯 on #324, and have a few other ideas for more substantial changes, but for major changes it would be good to have an idea of the state of testing (and more specifically, what _isn’t_ tested).

This patch adds coverage information to Travis outputs. This can be used to find parts of the codebase that still need testing.