### PR TITLE
Remove the conditional dependency on ordereddict

### DIFF
--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -1,7 +1,7 @@
 # img_info.py
 
 from PIL import Image
-from collections import deque
+from collections import deque, OrderedDict
 from constants import COMPLIANCE
 from constants import CONTEXT
 from constants import OPTIONAL_FEATURES
@@ -17,11 +17,6 @@ import struct
 from urllib import unquote
 
 from loris.utils import mkdir_p
-
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
 
 logger = getLogger(__name__)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 werkzeug >= 0.11.4
 pillow >= 2.4.0
 configobj >= 4.7.2,<=5.0.0
-ordereddict
 requests >= 2.12.0
 mock == 1.0.1
 responses == 0.3.0

--- a/setup.py
+++ b/setup.py
@@ -64,8 +64,6 @@ DEPENDENCIES = [
     ('mock', '==1.0.1', 'mock'),
     ('responses', '==0.3.0', 'responses')
 ]
-if version_info[1] < 7:
-    DEPENDENCIES.append(('ordereddict','>=1.1','ordereddict'))
 
 class LorisInstallCommand(install):
     description = 'Installs Loris image server'


### PR DESCRIPTION
OrderedDict was added to the standard library in Python 2.7, which is the minimum version supported by Loris.  It doesn't need to be imported from a third-party library any more.