### PR TITLE
Clean up imports for future Python 3 compatibility

### DIFF
--- a/loris/constants.py
+++ b/loris/constants.py
@@ -1,5 +1,8 @@
 # constants.py
 # -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
 import re
 
 COMPLIANCE = 'http://iiif.io/api/image/2/level2.json'

--- a/loris/img.py
+++ b/loris/img.py
@@ -1,15 +1,19 @@
 # img.py
 #-*-coding:utf-8-*-
 
+from __future__ import absolute_import
+
 from datetime import datetime
 from logging import getLogger
-from os import path, symlink, unlink, error as os_error, rename
-from parameters import RegionParameter
-from parameters import RotationParameter
-from parameters import SizeParameter
-from loris_exception import ImageException
-from urllib import unquote, quote_plus
-from urllib import unquote
+from os import path, symlink, unlink, rename
+
+try:
+    from urllib.parse import quote_plus, unquote
+except ImportError:  # Python 2
+    from urllib import quote_plus, unquote
+
+from loris.loris_exception import ImageException
+from loris.parameters import RegionParameter, RotationParameter, SizeParameter
 from loris.utils import mkdir_p
 
 logger = getLogger(__name__)

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -1,21 +1,25 @@
 # img_info.py
 
-from PIL import Image
+from __future__ import absolute_import
+
 from collections import deque, OrderedDict
-from constants import COMPLIANCE
-from constants import CONTEXT
-from constants import OPTIONAL_FEATURES
-from constants import PROTOCOL
 from datetime import datetime
 from logging import getLogger
-from loris_exception import ImageInfoException
 from math import ceil
 from threading import Lock
 import json
 import os
 import struct
-from urllib import unquote
 
+try:
+    from urllib.parse import unquote
+except ImportError:  # Python 2
+    from urllib import unquote
+
+from PIL import Image
+
+from loris.constants import COMPLIANCE, CONTEXT, OPTIONAL_FEATURES, PROTOCOL
+from loris.loris_exception import ImageInfoException
 from loris.utils import mkdir_p
 
 logger = getLogger(__name__)

--- a/loris/loris_exception.py
+++ b/loris/loris_exception.py
@@ -1,3 +1,6 @@
+from __future__ import absolute_import
+
+
 class LorisException(Exception):
 	"""Base exception class for Loris.
 

--- a/loris/parameters.py
+++ b/loris/parameters.py
@@ -8,12 +8,14 @@ The attributes of this class should make it possible to work with most imaging
 libraries without any further need to process the IIIF syntax.
 '''
 
+from __future__ import absolute_import
+
 import re
 from decimal import Decimal
 from math import floor
 from logging import getLogger
-from loris_exception import SyntaxException
-from loris_exception import RequestException
+
+from loris.loris_exception import RequestException, SyntaxException
 
 logger = getLogger(__name__)
 

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -3,22 +3,30 @@
 `resolver` -- Resolve Identifiers to Image Paths
 ================================================
 """
+
+from __future__ import absolute_import
+
 from logging import getLogger
-from loris_exception import ResolverException
 from os.path import join, exists, dirname
 from os import rename, remove
 from shutil import copy
 import tempfile
-from urllib import unquote, quote_plus
 from contextlib import closing
-
-import constants
 import hashlib
 import glob
-import requests
 import re
 
+try:
+    from urllib.parse import quote_plus, unquote
+except ImportError:  # Python 2
+    from urllib import quote_plus, unquote
+
+import requests
+
+from loris import constants
+from loris.loris_exception import ResolverException
 from loris.utils import mkdir_p
+
 
 logger = getLogger(__name__)
 

--- a/loris/transforms.py
+++ b/loris/transforms.py
@@ -1,26 +1,30 @@
 # transformers.py
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+
 import multiprocessing
-from PIL import Image
-from PIL.ImageFile import Parser
-from PIL.ImageOps import mirror
 from logging import getLogger
-from loris_exception import TransformException
 from math import ceil, log
 from os import path, unlink, devnull
-from parameters import FULL_MODE
 import cStringIO
 import platform
 import random
 import string
 import subprocess
 import sys
-try:
-    from PIL.ImageCms import profileToProfile # Pillow
-except ImportError:
-    from ImageCms import profileToProfile # PIL
 
+from PIL import Image
+from PIL.ImageFile import Parser
+from PIL.ImageOps import mirror
+
+try:
+    from PIL.ImageCms import profileToProfile  # Pillow
+except ImportError:
+    from ImageCms import profileToProfile  # PIL
+
+from loris.loris_exception import TransformException
+from loris.parameters import FULL_MODE
 from loris.utils import mkdir_p
 
 logger = getLogger(__name__)

--- a/loris/utils.py
+++ b/loris/utils.py
@@ -1,5 +1,7 @@
 # -*- encoding: utf-8 -*-
 
+from __future__ import absolute_import
+
 import errno
 import os
 

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -5,6 +5,8 @@ webapp.py
 =========
 Implements IIIF 2.0 <http://iiif.io/api/image/2.0/> level 2
 '''
+from __future__ import absolute_import
+
 from datetime import datetime
 from decimal import getcontext
 import logging
@@ -16,24 +18,23 @@ from subprocess import CalledProcessError
 from tempfile import NamedTemporaryFile
 from urllib import unquote, quote_plus
 
-#3rd party imports
 from configobj import ConfigObj
 from werkzeug.http import parse_date, http_date
-from werkzeug.wrappers import Request, Response, BaseResponse, CommonResponseDescriptorsMixin
+from werkzeug.wrappers import (
+	Request, Response, BaseResponse, CommonResponseDescriptorsMixin
+)
 
-#Loris imports
-import constants
-import img
-from img_info import ImageInfo
-from img_info import ImageInfoException
-from img_info import InfoCache
-from loris_exception import RequestException
-from loris_exception import SyntaxException
-from loris_exception import ImageException
-from loris_exception import ResolverException
-from loris_exception import TransformException
+from loris import constants, img, transforms
+from loris.img_info import ImageInfo, InfoCache
+from loris.loris_exception import (
+	ImageException,
+	ImageInfoException,
+	RequestException,
+	ResolverException,
+	SyntaxException,
+	TransformException,
+)
 from loris.utils import mkdir_p
-import transforms
 
 getcontext().prec = 25 # Decimal precision. This should be plenty.
 
@@ -57,13 +58,13 @@ def get_debug_config(debug_jp2_transformer):
     config['resolver']['impl'] = 'loris.resolver.SimpleFSResolver'
     config['resolver']['src_img_root'] = path.join(project_dp,'tests','img')
     if debug_jp2_transformer == 'opj':
-        from transforms import OPJ_JP2Transformer
+        from loris.transforms import OPJ_JP2Transformer
         opj_decompress = OPJ_JP2Transformer.local_opj_decompress_path()
         config['transforms']['jp2']['opj_decompress'] = path.join(project_dp, opj_decompress)
         libopenjp2_dir = OPJ_JP2Transformer.local_libopenjp2_dir()
         config['transforms']['jp2']['opj_libs'] = path.join(project_dp, libopenjp2_dir)
     else: # kdu
-        from transforms import KakaduJP2Transformer
+        from loris.transforms import KakaduJP2Transformer
         kdu_expand = KakaduJP2Transformer.local_kdu_expand_path()
         config['transforms']['jp2']['kdu_expand'] = path.join(project_dp, kdu_expand)
         libkdu_dir = KakaduJP2Transformer.local_libkdu_dir()

--- a/tests/abstract_resolver.py
+++ b/tests/abstract_resolver.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from loris import loris_exception
 
 

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -1,15 +1,21 @@
 # img_info_t.py
 #-*- coding: utf-8 -*-
 
-from loris import img_info
-from loris import loris_exception
-from loris.constants import PROTOCOL
-from os import path
-from urllib import unquote
-from werkzeug.datastructures import Headers
-import json
-import loris_t
+from __future__ import absolute_import
 
+from os import path
+import json
+
+try:
+    from urllib.parse import unquote
+except ImportError:  # Python 2
+    from urllib import unquote
+
+from werkzeug.datastructures import Headers
+
+from loris import img_info, loris_exception
+from loris.constants import PROTOCOL
+import loris_t
 import webapp_t
 
 

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -15,8 +15,7 @@ from werkzeug.datastructures import Headers
 
 from loris import img_info, loris_exception
 from loris.constants import PROTOCOL
-import loris_t
-import webapp_t
+from tests import loris_t, webapp_t
 
 
 """

--- a/tests/img_t.py
+++ b/tests/img_t.py
@@ -1,14 +1,20 @@
 #-*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+
 from os.path import exists
 from os.path import islink
 from os.path import isfile
 from os.path import join
 import unittest
-from urllib import unquote
 
-from loris.loris_exception import ImageException
+try:
+    from urllib.parse import unquote
+except ImportError:  # Python 2
+    from urllib import unquote
+
 from loris import img, img_info
+from loris.loris_exception import ImageException
 import loris_t
 
 

--- a/tests/img_t.py
+++ b/tests/img_t.py
@@ -15,7 +15,7 @@ except ImportError:  # Python 2
 
 from loris import img, img_info
 from loris.loris_exception import ImageException
-import loris_t
+from tests import loris_t
 
 
 """

--- a/tests/loris_t.py
+++ b/tests/loris_t.py
@@ -94,7 +94,7 @@ class LorisTest(unittest.TestCase):
         self.test_png_uri = '%s/%s' % (self.URI_BASE,self.test_png_id)
         self.test_png_dims = (504,360) # w,h
         self.test_png_sizes = []
-        
+
         self.test_altpng_id = 'foo.png'
         self.test_altpng_fp = path.join(self.test_img_dir2,'foo.png')
 

--- a/tests/loris_t.py
+++ b/tests/loris_t.py
@@ -4,13 +4,17 @@
 '''
 Superclass for integration tests.
 '''
+from __future__ import absolute_import
+
 import unittest
-from loris.webapp import get_debug_config, Loris
 from os import path, listdir, unlink
 from shutil import rmtree
+from logging import getLogger
+
 from werkzeug.test import Client
 from werkzeug.wrappers import BaseResponse
-from logging import getLogger
+
+from loris.webapp import get_debug_config, Loris
 
 logger = getLogger(__name__)
 

--- a/tests/parameters_t.py
+++ b/tests/parameters_t.py
@@ -14,7 +14,7 @@ from loris.parameters import (
 	DECIMAL_ONE, FULL_MODE, PCT_MODE, PIXEL_MODE,
 	RegionParameter, RotationParameter, SizeParameter,
 )
-import loris_t
+from tests import loris_t
 
 """
 Parameter object tests. To run this test on its own, do:

--- a/tests/parameters_t.py
+++ b/tests/parameters_t.py
@@ -1,21 +1,20 @@
 # parameters_t.py
 #-*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+
 from decimal import Decimal
-from loris import img_info
-from loris.loris_exception import RequestException
-from loris.loris_exception import SyntaxException
-from loris.parameters import DECIMAL_ONE
-from loris.parameters import FULL_MODE
-from loris.parameters import PCT_MODE
-from loris.parameters import PIXEL_MODE
-from loris.parameters import RegionParameter
-from loris.parameters import RotationParameter
-from loris.parameters import SizeParameter
-import loris_t
 
 from hypothesis import given
 from hypothesis.strategies import text
+
+from loris import img_info
+from loris.loris_exception import RequestException, SyntaxException
+from loris.parameters import (
+	DECIMAL_ONE, FULL_MODE, PCT_MODE, PIXEL_MODE,
+	RegionParameter, RotationParameter, SizeParameter,
+)
+import loris_t
 
 """
 Parameter object tests. To run this test on its own, do:

--- a/tests/resolver_t.py
+++ b/tests/resolver_t.py
@@ -24,7 +24,7 @@ from loris.resolver import (
     SourceImageCachingResolver,
     SimpleFSResolver
 )
-import loris_t
+from tests import loris_t
 
 
 """

--- a/tests/resolver_t.py
+++ b/tests/resolver_t.py
@@ -1,26 +1,34 @@
 #-*- coding: utf-8 -*-
-from loris.loris_exception import ResolverException
-from loris.resolver import (
-        _AbstractResolver,
-        SimpleHTTPResolver,
-        TemplateHTTPResolver,
-        SourceImageCachingResolver,
-        SimpleFSResolver
-    )
+
+from __future__ import absolute_import
+
 from os.path import dirname
 from os.path import isfile
 from os.path import join
 from os.path import realpath
 from os.path import exists
 import unittest
-from urllib import unquote, quote_plus
 
-import loris_t
+try:
+    from urllib.parse import quote_plus, unquote
+except ImportError:  # Python 2
+    from urllib import quote_plus, unquote
+
 import responses
+
+from loris.loris_exception import ResolverException
+from loris.resolver import (
+    _AbstractResolver,
+    SimpleHTTPResolver,
+    TemplateHTTPResolver,
+    SourceImageCachingResolver,
+    SimpleFSResolver
+)
+import loris_t
 
 
 """
-Resolver tests. This may need to be modified if you change the resolver 
+Resolver tests. This may need to be modified if you change the resolver
 implementation. To run this test on its own, do:
 
 $ python -m unittest tests.resolver_t
@@ -66,10 +74,10 @@ class Test_SimpleFSResolver(loris_t.LorisTest):
 class Test_SourceImageCachingResolver(loris_t.LorisTest):
 
     def test_source_image_caching_resolver(self):
-        # First we need to change the resolver on the test instance of the 
+        # First we need to change the resolver on the test instance of the
         # application (overrides the config to use SimpleFSResolver)
         config = {
-            'source_root' : join(dirname(realpath(__file__)), 'img'), 
+            'source_root' : join(dirname(realpath(__file__)), 'img'),
             'cache_root' : self.app.img_cache.cache_root
         }
         self.app.resolver = SourceImageCachingResolver(config)

--- a/tests/simple_fs_resolver_ut.py
+++ b/tests/simple_fs_resolver_ut.py
@@ -1,7 +1,10 @@
-from .abstract_resolver import AbstractResolverTest
-from loris import resolver
+from __future__ import absolute_import
+
 import os
 import unittest
+
+from loris import resolver
+from tests.abstract_resolver import AbstractResolverTest
 
 
 class SimpleFSResolverTest(AbstractResolverTest, unittest.TestCase):

--- a/tests/simple_http_resolver_ut.py
+++ b/tests/simple_http_resolver_ut.py
@@ -1,9 +1,13 @@
-from loris.resolver import SimpleHTTPResolver
-from loris.loris_exception import ResolverException
+from __future__ import absolute_import
+
 import os
 import shutil
 import unittest
+
 import responses
+
+from loris.resolver import SimpleHTTPResolver
+from loris.loris_exception import ResolverException
 
 
 class SimpleHTTPResolverTest(unittest.TestCase):

--- a/tests/source_image_caching_resolver_ut.py
+++ b/tests/source_image_caching_resolver_ut.py
@@ -1,8 +1,11 @@
-from .abstract_resolver import AbstractResolverTest
-from loris import resolver
+from __future__ import absolute_import
+
 import os
 import shutil
 import unittest
+
+from tests.abstract_resolver import AbstractResolverTest
+from loris import resolver
 
 
 class SourceImageCachingResolverTest(AbstractResolverTest, unittest.TestCase):

--- a/tests/transforms_t.py
+++ b/tests/transforms_t.py
@@ -1,9 +1,14 @@
 #-*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 from cStringIO import StringIO
 import unittest
-import loris_t, operator, itertools
+import operator, itertools
+
 from PIL.ImageFile import Parser
+
 from loris import transforms
+import loris_t
 
 """
 Transformer tests. These right now these work with the kakadu and PIL

--- a/tests/transforms_t.py
+++ b/tests/transforms_t.py
@@ -8,7 +8,7 @@ import operator, itertools
 from PIL.ImageFile import Parser
 
 from loris import transforms
-import loris_t
+from tests import loris_t
 
 """
 Transformer tests. These right now these work with the kakadu and PIL

--- a/tests/webapp_t.py
+++ b/tests/webapp_t.py
@@ -1,19 +1,21 @@
 # webapp_t.py
 #-*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+
 from datetime import datetime
 from os import path, listdir
 from time import sleep
 from unittest import TestCase
+import re
+
 from werkzeug.datastructures import Headers
 from werkzeug.http import http_date
 from werkzeug.test import EnvironBuilder
 from werkzeug.wrappers import Request
-import re
+
+from loris import img_info, loris_exception, webapp
 import loris_t
-from loris import img_info
-from loris import webapp
-from loris import loris_exception
 
 
 """

--- a/tests/webapp_t.py
+++ b/tests/webapp_t.py
@@ -15,7 +15,7 @@ from werkzeug.test import EnvironBuilder
 from werkzeug.wrappers import Request
 
 from loris import img_info, loris_exception, webapp
-import loris_t
+from tests import loris_t
 
 
 """


### PR DESCRIPTION
*   Add `from __future__ import absolute_import` to get Python 3-style absolute imports, and convert the existing loris imports
*   Handle renamed modules in the Py3 standard library (currently just `urllib`)
*   Rearrange imports into PEP 8-style groups of stdlib, third-party and library-specific imports

Related to #324.