### PR TITLE
Switch to using py.test as the test runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
  - pip install -r requirements_test.txt
 
 script:
-  - "coverage run -m py.test tests/*.py"
+  - "coverage run --module py.test --verbose tests/*.py"
   - "coverage report"
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
  - pip install -r requirements_test.txt
 
 script:
-  - "coverage run ./test.py"
+  - "coverage run -m py.test tests/*.py"
   - "coverage report"
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ python:
  - "2.7"
 
 install:
- - pip install -r requirements.txt
  - pip install -r requirements_test.txt
 
 script:

--- a/doc/develop.md
+++ b/doc/develop.md
@@ -36,13 +36,26 @@ __N.B.:__ When developing or extending, i.e., instantiating the application inst
 
 Running Tests
 -------------
-To run all of the tests, you need to install test dependencies:
+To run the tests, you need to install test dependencies:
 
 ```console
 $ pip install -r requirements_test.txt
 ```
 
-Then run `./test.py` from the `/loris` directory (not `/loris/loris`). If you just want to run the tests for a single module, do, e.g. `python -m unittest -v tests.parameters_t` from the same dir as above.
+Then, in the root of the repository, run:
+
+```console
+$ coverage run -m py.test tests/*.py
+$ coverage report
+```
+
+This will run the tests, and print coverage information for the ``loris`` directory.
+If you'd like to run a specific test, pass a filename to ``coverage run``.
+For example:
+
+```console
+$ coverage run -m py.test tests/parameters_t.py
+```
 
 Using the Development Server
 ----------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,3 @@ werkzeug >= 0.11.4
 pillow >= 2.4.0
 configobj >= 4.7.2,<=5.0.0
 requests >= 2.12.0
-mock == 1.0.1
-responses == 0.3.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,4 @@
 coverage==4.4.1
 hypothesis >= 3.11.6
+pytest-cov==2.5.1
+pytest==3.1.3

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,3 +3,4 @@ coverage==4.4.1
 hypothesis >= 3.11.6
 pytest-cov==2.5.1
 pytest==3.1.3
+responses == 0.3.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 coverage==4.4.1
 hypothesis >= 3.11.6
 pytest-cov==2.5.1

--- a/setup.py
+++ b/setup.py
@@ -61,8 +61,6 @@ DEPENDENCIES = [
     ('pillow', '>=2.4.0', 'PIL'),
     ('configobj', '>=4.7.2,<=5.0.0', 'configobj'),
     ('requests', '>=2.12.0', 'requests'),
-    ('mock', '==1.0.1', 'mock'),
-    ('responses', '==0.3.0', 'responses')
 ]
 
 class LorisInstallCommand(install):


### PR DESCRIPTION
This patch swaps out the test runner to be py.test, not unittest. Using py.test has a number of nice features:

* Cleaner, more Pythonic asserts
* Parameterized tests
* Less testing boilerplate

For now, I’ve just flipped the test runner – converting the test code at the same time would be a much more unwieldy patch.

While I was poking test infrastructure, a few other changes:

* Don’t install the mock and responses dependencies by default – responses only when we‘re running tests, mock not at all (turns out, it’s never used in the current test suite)
* Installing from `requirements_test.txt` now gets you everything in `requirements.txt` as well, so there’s one less command to run
* Developer docs have been updated with new instructions