### PR TITLE
Updating Little CMS color management library utility package name

### DIFF
--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -1,7 +1,7 @@
 Installing Dependencies
 =======================
 
-These instructions are known to work with Ubuntu 12.04, Ubuntu 14.04 and Ubuntu 16.04. If you have further information, please provide it!
+These instructions are known to work with Ubuntu 14.04 and Ubuntu 16.04. If you have further information, please provide it!
 
 Loris (Pillow, actually, with the exception of Kakadu) depends on several external libraries that can't be installed with pip, so there are few steps that must be carefully followed to get going. Installing the dependencies manually is a good idea if you want to run the tests.
 

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -1,7 +1,7 @@
 Installing Dependencies
 =======================
 
-These instructions are known to work with Ubuntu 12.04 and Ubuntu 14.04. If you have further information, please provide it!
+These instructions are known to work with Ubuntu 12.04, Ubuntu 14.04 and Ubuntu 16.04. If you have further information, please provide it!
 
 Loris (Pillow, actually, with the exception of Kakadu) depends on several external libraries that can't be installed with pip, so there are few steps that must be carefully followed to get going. Installing the dependencies manually is a good idea if you want to run the tests.
 

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -28,7 +28,7 @@ Pillow's external dependencies __MUST__ be built/installed before Pillow is inst
 Then, install all of the dependencies--note that exact versions may vary depending on your package manager and OS version:
 
     $ sudo apt-get install libjpeg-turbo8-dev libfreetype6-dev zlib1g-dev \
-    liblcms2-dev liblcms-utils libtiff5-dev python-dev libwebp-dev apache2 \
+    liblcms2-dev liblcms2-utils libtiff5-dev python-dev libwebp-dev apache2 \
     libapache2-mod-wsgi
 
 Now install Pillow (setup.py would do this for you, but it's better to do separately and check):


### PR DESCRIPTION
Changing to `liblcms2-utils` as `liblcms-utils` is no longer available.
**OS:** Ubuntu 16.04 LTS 64-bits

```
jigyasa@jigyasa:~$ sudo apt-get install liblcms-utils
[sudo] password for jigyasa: 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package liblcms-utils

jigyasa@jigyasa:~$ sudo apt-get install liblcms2-utils
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following NEW packages will be installed:
  liblcms2-utils
0 upgraded, 1 newly installed, 0 to remove and 303 not upgraded.
Need to get 40.1 kB of archives.
After this operation, 187 kB of additional disk space will be used.
Get:1 http://ca.archive.ubuntu.com/ubuntu xenial/main amd64 liblcms2-utils amd64 2.6-3ubuntu2 [40.1 kB]
Fetched 40.1 kB in 0s (63.0 kB/s)   
Selecting previously unselected package liblcms2-utils.
(Reading database ... 179482 files and directories currently installed.)
Preparing to unpack .../liblcms2-utils_2.6-3ubuntu2_amd64.deb ...
Unpacking liblcms2-utils (2.6-3ubuntu2)
```