### PR TITLE
Callbacks for LorisResponse.close() should be functions, not results

### DIFF
--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -621,7 +621,7 @@ possible that there was a problem with the source file
         r.response = file(fp)
 
         if not self.enable_caching:
-            r.call_on_close(unlink(fp))
+            r.call_on_close(lambda: unlink(fp))
 
         return r
 

--- a/tests/webapp_t.py
+++ b/tests/webapp_t.py
@@ -433,16 +433,22 @@ class WebappIntegration(loris_t.LorisTest):
     def test_cleans_up_when_caching(self):
         self.app.enable_caching = True
         to_get = '/%s/full/full/0/default.jpg' % (self.test_jp2_color_id,)
-        resp = self.client.get(to_get)
-        self._tmp_has_no_files()
+        # We use the response as a context manager to ensure it gets
+        # closed before the test ends.
+        with self.client.get(to_get):
+            pass
+        self._assert_tmp_has_no_files()
 
     def test_cleans_up_when_not_caching(self):
         self.app.enable_caching = False
         to_get = '/%s/full/full/0/default.jpg' % (self.test_jp2_color_id,)
-        resp = self.client.get(to_get)
-        self._tmp_has_no_files()
+        # We use the response as a context manager to ensure it gets
+        # closed before the test ends.
+        with self.client.get(to_get):
+            pass
+        self._assert_tmp_has_no_files()
 
-    def _tmp_has_no_files(self):
+    def _assert_tmp_has_no_files(self):
         # callback should delete the image before the test ends, so the tmp dir
         # should not contain any files (there may be dirs)
         tmp = self.app.tmp_dp


### PR DESCRIPTION
Resolves #341.