### PR TITLE
Correct name of SRGB profile conversion flag in docs

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -55,10 +55,10 @@ Any options you add here will be passed through to the resolver you implement. F
 Probably safe to leave these as-is unless you care about something very specific. See the [Developer Notes](develop.md#image-transformations) for when this may not be the case. The exceptions are `kdu_expand` and `kdu_libs` in the `[transforms.jp2]` (see [Installing Dependencies](dependencies.md) step 2) or if you're not concerned about color profiles (see next).
 
 ### `[transforms][[jp2]]`
- * `map_embedded_profile_to_srgb`. If set to `map_embedded_profile_to_srgb = True` and you provide a path to an sRGB color profile on your system, e.g.:
+ * `map_profile_to_srgb`. If set to `map_profile_to_srgb = True` and you provide a path to an sRGB color profile on your system, e.g.:
 ```
 ...
-map_embedded_profile_to_srgb=True
+map_profile_to_srgb=True
 srgb_profile_fp=/usr/share/color/icc/colord/sRGB.icc
 ```
 

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -58,7 +58,7 @@ class ImageInfo(object):
 
         src_img_fp (str): the absolute path on the file system [non IIIF]
         src_format (str): the format of the source image file [non IIIF]
-        color_profile_bytes []: the emebedded color profile, if any [non IIIF]
+        color_profile_bytes []: the embedded color profile, if any [non IIIF]
         auth_rules (dict): extra information about authorization [non IIIF]
 
     '''


### PR DESCRIPTION
The code that parses this flag can be found in https://github.com/loris-imageserver/loris/blob/development/loris/transforms.py#L158