### PR TITLE
Unrecognised idents in TemplateHTTPTransformer should be 404, not 500

### DIFF
--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -339,8 +339,6 @@ class SimpleHTTPResolver(_AbstractResolver):
 
     def copy_to_cache(self, ident):
         ident = unquote(ident)
-        cache_dir = self.cache_dir_path(ident)
-        mkdir_p(cache_dir)
 
         #get source image and write to temporary file
         (source_url, options) = self._web_request_url(ident)
@@ -353,6 +351,9 @@ class SimpleHTTPResolver(_AbstractResolver):
             )
             logger.warn('Unable to determine source URL for ident %r', ident)
             raise ResolverException(404, public_message)
+
+        cache_dir = self.cache_dir_path(ident)
+        mkdir_p(cache_dir)
 
         with closing(requests.get(source_url, stream=True, **options)) as response:
             if not response.ok:

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -404,36 +404,59 @@ class SimpleHTTPResolver(_AbstractResolver):
 
 
 class TemplateHTTPResolver(SimpleHTTPResolver):
-    '''HTTP resolver that suppors multiple configurable patterns for supported
-    urls.  Based on SimpleHTTPResolver.  Identifiers in URLs should be
-    specified as `template_name:id`.
+    """
+    An HTTP resolver that supports multiple configurable patterns for
+    supported URLs.  It is based on SimpleHTTPResolver.  Identifiers in URLs
+    should be specified as ``template_name:id``.
 
-    The configuration MUST contain
-     * `cache_root`, which is the absolute path to the directory where source images
-        should be cached.
+    It has the same mandatory config as SimpleHTTPResolver (must specify
+    ``cache_root``, one of ``source_prefix`` or ``uri_resolvable=True``).
 
-    The configuration SHOULD contain
-     * `templates`, a comma-separated list of template names e.g.
-        templates=`site1,site2`
-     * A subsection named for each template, e.g. `[[site1]]`. This subsection
-       MUST contain a `url`, which is a url pattern for each specified template, e.g.
-       url='http://example.edu/images/%s' or
-       url='http://example.edu/images/%s/master'. It MAY also contain other keys
-       from the SimpleHTTPResolver configuration to provide a per-template
-       override of these options. Overridable keys are `user`, `pw`,
-       `ssl_check`, `cert`, and `key`.
+    The configuration should contain:
 
-    Note that if a template is listed but has no pattern configured, the
-    resolver will warn but not fail.
+    *   ``templates``, a comma-separated list of template names.  For example:
 
-    The configuration may also include the following settings, as used by
-    SimpleHTTPResolver:
-     * `default_format`, the format of images (will use content-type of
-        response if not specified).
-     * `head_resolvable` with value True, whether to make HEAD requests
-        to verify object existence (don't set if using Fedora Commons
-        prior to 3.8).  [Currently must be the same for all templates]
-    '''
+            templates = 'site1,site2'
+
+    *   A named subsection for each template.  This subsection MUST contain
+        a ``url``, with a URL pattern for each template.  For example:
+
+            [[site1]]
+            url = 'http://example.edu/images/%'
+
+            [[site2]]
+            url = 'https://example.edu/images/%s/master'
+
+        Each subsection MAY also contain other keys from the SimpleHTTPResolver
+        configuration to provide a per-template override of each of these
+        options -- ``user``, ``pw``, ``ssl_check``, ``cert`` and ``key``.
+
+    If a template is listed but has no pattern configured, the resolver
+    will warn but not error.
+
+    If a template has multiple fill-in sections, you can pass a ``delimiter``
+    option to the global config.  When an identifier is received, it will
+    be split on this delimiter to get the different parts.  For example:
+
+        templates = 'site'
+        delimiter = '|'
+
+        [[site]]
+        url = 'http://example.edu/images/%/dir/%s'
+
+    Making a request for identifier ``site:red|yellow`` would resolve to the
+    URL ``http://example.edu/images/red/dir/yellow``.
+
+    The configuration may also include the following settings, as used
+    by SimpleHTTPResolver:
+
+    *   ``default_format``, the format of images (will use the Content-Type
+        of the response if unspecified)
+    *   ``head_resolvable`` with value True, whether to make HEAD requests
+        to validate object existence (don't set if using Fedora Commons
+        prior to 3.8.)  [Currently must be the same for all templates.]
+
+    """
     def __init__(self, config):
         # required for simplehttpresolver
         # all templates are assumed to be uri resolvable

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -344,6 +344,16 @@ class SimpleHTTPResolver(_AbstractResolver):
 
         #get source image and write to temporary file
         (source_url, options) = self._web_request_url(ident)
+
+        # If we can't find a source URL to retrieve the image from, there's
+        # no point trying to look it up.
+        if source_url is None:
+            public_message = (
+                'Source image not found for identifier: %s.' % ident
+            )
+            logger.warn('Unable to determine source URL for ident %r', ident)
+            raise ResolverException(404, public_message)
+
         with closing(requests.get(source_url, stream=True, **options)) as response:
             if not response.ok:
                 public_message = 'Source image not found for identifier: %s. Status code returned: %s' % (ident,response.status_code)

--- a/tests/resolver_t.py
+++ b/tests/resolver_t.py
@@ -14,6 +14,7 @@ try:
 except ImportError:  # Python 2
     from urllib import quote_plus, unquote
 
+import pytest
 import responses
 
 from loris.loris_exception import ResolverException
@@ -309,6 +310,19 @@ class Test_TemplateHTTPResolver(loris_t.LorisTest):
             self.app.resolver._web_request_url('c:foo:bar:baz')[0])
         self.assertEqual(None,
             self.app.resolver._web_request_url('unknown:id2')[0])
+
+    def test_looking_up_unrecognised_ident_is_404(self):
+        config = {
+            'cache_root' : self.app.img_cache.cache_root,
+            'templates': 'x',
+            'x': {'url': 'http://example.org/images/%s'},
+        }
+        resolver = TemplateHTTPResolver(config)
+        with pytest.raises(ResolverException) as exc:
+            resolver.copy_to_cache('foo')
+
+        assert exc.value.http_status == 404
+        assert 'Source image not found' in exc.value.message
 
 
 def suite():

--- a/tests/resolver_t.py
+++ b/tests/resolver_t.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import
 
+import copy
 from os.path import dirname
 from os.path import isfile
 from os.path import join
@@ -361,8 +362,7 @@ class Test_TemplateHTTPResolver(object):
         ({'ssl_check': False}, {'verify': False}),
     ])
     def test_adding_options_to_parsed_uri(self, config, expected_options):
-        new_config = {k: v for k, v in self.config.items()}
-        print(new_config)
+        new_config = copy.deepcopy(self.config)
         new_config['a'].update(config)
         resolver = TemplateHTTPResolver(new_config)
         _, options = resolver._web_request_url('a:id1.jpg')

--- a/tests/resolver_t.py
+++ b/tests/resolver_t.py
@@ -319,7 +319,7 @@ class Test_TemplateHTTPResolver(object):
 
     delimited_config = {
         'cache_root' : '/var/cache/loris',
-        'templates': 'delim',
+        'templates': 'delim1, delim2',
         'delimiter': '|',
         'delim1': {
             'url': 'http://mysite.com/images/%s/access/%s'
@@ -330,16 +330,16 @@ class Test_TemplateHTTPResolver(object):
     }
 
     @pytest.mark.parametrize('ident, expected_uri', [
-        ('delim:foo|bar', 'http://mysite.com/images/foo/access/bar'),
+        ('delim1:foo|bar', 'http://mysite.com/images/foo/access/bar'),
         ('delim2:red|green|blue', 'http://anothersite.com/img/red/files/green/dir/blue'),
     ])
     def test_using_delimiters_for_template(self, ident, expected_uri):
         resolver = TemplateHTTPResolver(self.delimited_config)
-        uri, _ = resolver._web_request_url('delim:foo|bar')
+        uri, _ = resolver._web_request_url(ident)
         assert uri == expected_uri
 
     @pytest.mark.parametrize('bad_ident', [
-        'delim:up|down|left|right',
+        'delim1:up|down|left|right',
         'nodelim',
     ])
     def test_bad_delimited_ident_is_resolvererror(self, bad_ident):


### PR DESCRIPTION
This resolves an issue originally raised as https://github.com/wellcometrust/platform/issues/786

TemplateHTTPResolver uses `_web_request_url` to get the source URL for an ident; if it doesn't find something that matches one of the templates, it returns None. It then attempts to download the source image as `requests.get(None)`, which throws a MissingSchema exception. This bubbles up and manifests as a 500 error to the user.

The correct response is a 404 – Loris is unable to find the ident in question.

This patch throws a 404 in the case where the resolver can't pick a source URL, and adds a test for this path. It also skips creating the cache directory until we have a plausible source URL, so errors return slightly faster.

This patch is ready for review.