### PR TITLE
Make sure that an empty InfoCache really is empty

### DIFF
--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -492,3 +492,6 @@ class InfoCache(object):
             os.unlink(icc_fp)
 
         os.removedirs(os.path.dirname(info_fp))
+
+    def __len__(self):
+        return len(self._dict)

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -385,8 +385,8 @@ class InfoCache(object):
         self.http_root = os.path.join(root, 'http')
         self.https_root = os.path.join(root, 'https')
         self.size = size
-        self._dict = OrderedDict(last=False) # keyed with the URL, so we don't
-                                             # need toseparate HTTP and HTTPS
+        self._dict = OrderedDict()  # keyed by URL, so we don't need
+                                    # to separate HTTP and HTTPS
         self._lock = Lock()
 
     def _which_root(self, request):

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -376,6 +376,10 @@ class InfoCache(loris_t.LorisTest):
         cache[req] = info
         del cache[req]
 
+    def test_empty_cache_has_zero_size(self):
+        cache = img_info.InfoCache(root=self.SRC_IMAGE_CACHE)
+        assert len(cache) == 0
+
 
 def suite():
     import unittest


### PR DESCRIPTION
I spotted a bug while trying to write some other tests for InfoCache – when you create an empty cache, it already contains one item – `('last', None)`. The constructor for OrderedDict is misinterpreting this argument as some initial keys.

This patch adds a test to catch it, and corrects the behaviour.