### PR TITLE
Get to 100% line coverage of img.py

### DIFF
--- a/loris/img.py
+++ b/loris/img.py
@@ -180,7 +180,7 @@ class ImageRequest(object):
     @property
     def is_canonical(self):
         if self._is_canonical is None:
-            self._is_canonical = self.as_path == self.canonical_as_path
+            self._is_canonical = (self.as_path == self.canonical_as_path)
         return self._is_canonical
 
     @property

--- a/loris/utils.py
+++ b/loris/utils.py
@@ -3,11 +3,15 @@
 from __future__ import absolute_import
 
 import errno
+import logging
 import os
 
 
+logger = logging.getLogger(__name__)
+
+
 def mkdir_p(path):
-    '''Create a directory if it doesn't already exist.'''
+    """Create a directory if it doesn't already exist."""
     try:
         os.makedirs(path)
     except OSError as err:
@@ -15,3 +19,25 @@ def mkdir_p(path):
             pass
         else:
             raise
+
+
+def symlink(src, dst, force=True):
+    """Create a symlink from ``src`` to ``dst``.
+
+    Creates any required intermediate directories, and overrides any existing
+    file at ``dst``.
+
+    """
+    if src == dst:
+        logger.warn(
+            'Circular symlink requested from %s to %s; not creating symlink',
+            src, dst)
+        return
+
+    mkdir_p(os.path.dirname(dst))
+
+    # Shouldn't be the case, but helps with debugging.
+    if os.path.lexists(dst):
+        os.unlink(dst)
+
+    os.symlink(src, dst)

--- a/tests/img_t.py
+++ b/tests/img_t.py
@@ -8,6 +8,7 @@ from os.path import isfile
 from os.path import join
 import unittest
 
+import mock
 import pytest
 
 try:
@@ -111,6 +112,16 @@ class Test_ImageCache(loris_t.LorisTest):
         request = img.ImageRequest('id1', 'full', 'full', '0', 'default', 'jpg')
 
         self.assertIsNone(cache.get(request))
+
+    def test_getitem_with_unexpected_error_is_raised(self):
+        cache = img.ImageCache(cache_root='/tmp')
+        request = img.ImageRequest('id', 'full', 'full', '0', 'default', 'jpg')
+
+        message = "Exception thrown in img_t.py for Test_ImageCache"
+        m = mock.Mock(side_effect=OSError(-1, message))
+        with mock.patch('loris.img.path.getmtime', m):
+            with pytest.raises(OSError) as err:
+                cache[request]
 
 
 def suite():

--- a/tests/utils_t.py
+++ b/tests/utils_t.py
@@ -33,5 +33,47 @@ class TestMkdirP:
 
         m = mock.Mock(side_effect=OSError(-1, message))
         with mock.patch('loris.utils.os.makedirs', m):
-            with pytest.raises(OSError) as err:
+            with pytest.raises(OSError):
                 utils.mkdir_p(path)
+
+
+@pytest.fixture
+def symlink_src(tmpdir):
+    path = str(tmpdir.join('symlink_src'))
+    open(path, 'wb').write(b'I am a symlink')
+    yield path
+    os.unlink(path)
+
+
+class TestSymlink:
+
+    @staticmethod
+    def _assert_is_symlink(src, dst):
+        assert os.path.exists(dst)
+        assert os.path.islink(dst)
+        assert os.path.realpath(dst) == src
+
+    def test_creates_symlink(self, symlink_src, tmpdir):
+        dst = str(tmpdir.join('foo'))
+        utils.symlink(symlink_src, dst)
+        self._assert_is_symlink(symlink_src, dst)
+
+    def test_creates_intermediate_directories(self, symlink_src, tmpdir):
+        dst = str(tmpdir.join('foo/bar/baz'))
+        utils.symlink(symlink_src, dst)
+        self._assert_is_symlink(symlink_src, dst)
+
+    def test_circular_symlink_is_ignored(self, symlink_src):
+        utils.symlink(symlink_src, symlink_src)
+        assert os.path.isfile(symlink_src)
+
+    def test_old_symlink_is_replaced(self, symlink_src, tmpdir):
+        # Create the dst, and write some text into it
+        dst = str(tmpdir.join('foo'))
+        open(dst, 'wb').write(b'I am the old file')
+
+        # Now create a symlink to dst, and check it's become a symlink, and
+        # the old contents are gone
+        utils.symlink(symlink_src, dst)
+        self._assert_is_symlink(symlink_src, dst)
+        assert open(dst, 'wb') != b'I am the old file'


### PR DESCRIPTION
I also had to move some symlinking code into `utils.py` and test it there, rather than testing an underscore method on ImageCache.