### PR TITLE
Switch to consistent use of spaces throughout

### DIFF
--- a/loris/constants.py
+++ b/loris/constants.py
@@ -18,13 +18,13 @@ OPTIONAL_FEATURES = [
 ]
 
 __formats = (
-	('gif','image/gif'),
-	('jp2','image/jp2'),
-	('jpg','image/jpeg'),
-	('pdf','application/pdf'),
-	('png','image/png'),
-	('tif','image/tiff'),
-	('webp','image/webp'),
+    ('gif','image/gif'),
+    ('jp2','image/jp2'),
+    ('jpg','image/jpeg'),
+    ('pdf','application/pdf'),
+    ('png','image/png'),
+    ('tif','image/tiff'),
+    ('webp','image/webp'),
 )
 
 FORMATS_BY_EXTENSION = dict(__formats)

--- a/loris/loris_exception.py
+++ b/loris/loris_exception.py
@@ -2,26 +2,26 @@ from __future__ import absolute_import
 
 
 class LorisException(Exception):
-	"""Base exception class for Loris.
+    """Base exception class for Loris.
 
-	See <http://www-sul.stanford.edu/iiif/image-api/#error>
+    See <http://www-sul.stanford.edu/iiif/image-api/#error>
 
-	Attributes:
-		http_status (int): the HTTP status the should be sent with the response.
-		supplied_value (str): the parameter that caused the problem.
-		msg (str): any additional info about what went wrong.
-	"""
-	def __init__(self, http_status=400, message=''):
-		"""
-		Kwargs:
-			http_status (int): the HTTP status the should be sent with the
-				response.
-			msg (str): any additional info about what went wrong.
-			supplied_value (str): the parameter that caused the problem.
-		"""
-		# message = '%s: %s (%d)' % (self.__class__.__name__, message, http_status)
-		super(LorisException, self).__init__(message)
-		self.http_status = http_status
+    Attributes:
+        http_status (int): the HTTP status the should be sent with the response.
+        supplied_value (str): the parameter that caused the problem.
+        msg (str): any additional info about what went wrong.
+    """
+    def __init__(self, http_status=400, message=''):
+        """
+        Kwargs:
+            http_status (int): the HTTP status the should be sent with the
+                response.
+            msg (str): any additional info about what went wrong.
+            supplied_value (str): the parameter that caused the problem.
+        """
+        # message = '%s: %s (%d)' % (self.__class__.__name__, message, http_status)
+        super(LorisException, self).__init__(message)
+        self.http_status = http_status
 
 class SyntaxException(LorisException): pass
 class RequestException(LorisException): pass

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -25,19 +25,19 @@ from configobj import ConfigObj
 from werkzeug.http import parse_date, http_date
 
 from werkzeug.wrappers import (
-	Request, Response, BaseResponse, CommonResponseDescriptorsMixin
+    Request, Response, BaseResponse, CommonResponseDescriptorsMixin
 )
 
 from loris import constants, img, transforms
 from loris.img_info import ImageInfo, InfoCache
 from loris.loris_exception import (
-	ConfigError,
-	ImageException,
-	ImageInfoException,
-	RequestException,
-	ResolverException,
-	SyntaxException,
-	TransformException,
+    ConfigError,
+    ImageException,
+    ImageInfoException,
+    RequestException,
+    ResolverException,
+    SyntaxException,
+    TransformException,
 )
 
 
@@ -82,7 +82,7 @@ def get_debug_config(debug_jp2_transformer):
 
     config['authorizer'] = {'impl': 'loris.authorizer.RulesAuthorizer'}
     config['authorizer']['cookie_secret'] = "4rakTQJDyhaYgoew802q78pNnsXR7ClvbYtAF1YC87o="
-    config['authorizer']['token_secret'] = "hyQijpEEe9z1OB9NOkHvmSA4lC1B4lu1n80bKNx0Uz0="     
+    config['authorizer']['token_secret'] = "hyQijpEEe9z1OB9NOkHvmSA4lC1B4lu1n80bKNx0Uz0="
     config['authorizer']['roles_key'] = 'roles'
     config['authorizer']['id_key'] = 'sub'
 
@@ -372,7 +372,7 @@ class Loris(object):
         except:
             return None
         AuthorizerClass = self._import_class(impl)
-        return AuthorizerClass(self.app_configs['authorizer'])                
+        return AuthorizerClass(self.app_configs['authorizer'])
 
     def _import_class(self, qname):
         '''Imports a class AND returns it (the class, not an instance).
@@ -422,7 +422,7 @@ class Loris(object):
                 r = LorisResponse()
                 r.set_acao(request)
                 r.status_code = 200
-                return r                
+                return r
 
             return self.get_info(request, ident, base_uri)
 
@@ -481,7 +481,7 @@ class Loris(object):
         last_mod = parse_date(http_date(last_mod)) # see note under get_img
 
         if self.authorizer and self.authorizer.is_protected(info):
-            authed = self.authorizer.is_authorized(info, request)            
+            authed = self.authorizer.is_authorized(info, request)
             if authed['status'] == 'deny':
                 r.status_code = 401
                 # trash If-Mod-Since to ensure no 304
@@ -567,7 +567,7 @@ class Loris(object):
             in_cache = False
 
         try:
-            # We need the info to check authorization, 
+            # We need the info to check authorization,
             # ... still cheaper than always resolving as likely to be cached
             info = self._get_info(ident, request, base_uri)[0]
         except ResolverException as re:

--- a/misc/openjpeg_transform.py
+++ b/misc/openjpeg_transform.py
@@ -9,11 +9,11 @@ import subprocess
 import sys
 
 def mk_tile_with_PIL():
-	jp2_with_tiles_fp = '../tests/img/01/02/0001.jp2'
-	im = Image.open(jp2_with_tiles_fp)
-	im.reduce = 2
-	im = im.crop((0,0,256,256))
-	im.save('/tmp/out.jpg')
+    jp2_with_tiles_fp = '../tests/img/01/02/0001.jp2'
+    im = Image.open(jp2_with_tiles_fp)
+    im.reduce = 2
+    im = im.crop((0,0,256,256))
+    im.save('/tmp/out.jpg')
 
 setup = 'from __main__ import mk_tile_with_PIL'
 t = timeit.timeit('mk_tile_with_PIL()', setup=setup, number=3)
@@ -21,53 +21,53 @@ print 'Average with PIL: %0.6f' % (t,)
 
 
 def mk_tile_subproc():
-	opj_bin = '/usr/local/bin/opj_decompress'
-	opj_lib = '/usr/local/lib/libopenjp2.so'
-	pipe_o = '/tmp/mypipe.bmp'
-	out_jpg = '/tmp/test.jpg'
-	mkfifo_cmd = '/usr/bin/mkfifo %s' % (pipe_o,)
-	rmfifo_cmd = '/bin/rm %s' % (pipe_o,)
-	i = '../tests/img/01/02/0001.jp2'
-	r = 2 # reduce
-	# d = '256,256,512,512'
-	d = '0,0,256,256'
+    opj_bin = '/usr/local/bin/opj_decompress'
+    opj_lib = '/usr/local/lib/libopenjp2.so'
+    pipe_o = '/tmp/mypipe.bmp'
+    out_jpg = '/tmp/test.jpg'
+    mkfifo_cmd = '/usr/bin/mkfifo %s' % (pipe_o,)
+    rmfifo_cmd = '/bin/rm %s' % (pipe_o,)
+    i = '../tests/img/01/02/0001.jp2'
+    r = 2 # reduce
+    # d = '256,256,512,512'
+    d = '0,0,256,256'
 
-	opj_cmd = '%s -i %s -o %s -d %s -r %s' % (opj_bin, i, pipe_o, d, r)
+    opj_cmd = '%s -i %s -o %s -d %s -r %s' % (opj_bin, i, pipe_o, d, r)
 
-	# make a named pipe
-	mkfifo_resp = subprocess.check_call(mkfifo_cmd, shell=True)
-	if mkfifo_resp != 0:
-	    sys.stderr.write('mkfifo not OK\n')
+    # make a named pipe
+    mkfifo_resp = subprocess.check_call(mkfifo_cmd, shell=True)
+    if mkfifo_resp != 0:
+        sys.stderr.write('mkfifo not OK\n')
 
-	# write opj_decompress's output to the named pipe 
-	opj_proc = subprocess.Popen(opj_cmd, shell=True, 
-	    bufsize=-1, stderr=subprocess.PIPE, stdout=subprocess.PIPE,
-	    env={ 'LD_LIBRARY_PATH' : opj_lib })
+    # write opj_decompress's output to the named pipe
+    opj_proc = subprocess.Popen(opj_cmd, shell=True,
+        bufsize=-1, stderr=subprocess.PIPE, stdout=subprocess.PIPE,
+        env={ 'LD_LIBRARY_PATH' : opj_lib })
 
-	# open the named pipe and parse the stream
-	im = None
-	with open(pipe_o, 'rb') as f:
-	    p = Parser()
-	    while True:
-	        s = f.read(1024)
-	        if not s:
-	            break
-	        p.feed(s)
-	    im = p.close()
+    # open the named pipe and parse the stream
+    im = None
+    with open(pipe_o, 'rb') as f:
+        p = Parser()
+        while True:
+            s = f.read(1024)
+            if not s:
+                break
+            p.feed(s)
+        im = p.close()
 
-	# finish opj
-	opj_exit = opj_proc.wait()
-	if opj_exit != 0:
-	    map(sys.stderr.write, opj_proc.stderr)
-	else:
-	    # opj was successful, save to a jpg
-	    # map(sys.stdout.write, opj_proc.stdout)
-	    im.save(out_jpg, quality=95)
+    # finish opj
+    opj_exit = opj_proc.wait()
+    if opj_exit != 0:
+        map(sys.stderr.write, opj_proc.stderr)
+    else:
+        # opj was successful, save to a jpg
+        # map(sys.stdout.write, opj_proc.stdout)
+        im.save(out_jpg, quality=95)
 
-	# remove the named pipe
-	rmfifo_resp = subprocess.check_call(rmfifo_cmd, shell=True)
-	if rmfifo_resp != 0:
-	    sys.stderr.write('rm fifo not OK\n')
+    # remove the named pipe
+    rmfifo_resp = subprocess.check_call(rmfifo_cmd, shell=True)
+    if rmfifo_resp != 0:
+        sys.stderr.write('rm fifo not OK\n')
 
 setup = 'from __main__ import mk_tile_subproc'
 t = timeit.timeit('mk_tile_subproc()', setup=setup, number=3)

--- a/tests/authorizer_t.py
+++ b/tests/authorizer_t.py
@@ -1,6 +1,6 @@
 
 from loris.authorizer import _AbstractAuthorizer, NullAuthorizer,\
-	NooneAuthorizer, SingleDegradingAuthorizer, RulesAuthorizer
+    NooneAuthorizer, SingleDegradingAuthorizer, RulesAuthorizer
 from loris.img_info import ImageInfo
 
 import unittest
@@ -11,287 +11,287 @@ import pytest
 
 class MockRequest(object):
 
-	def __init__(self, hdrs={}, cooks={}):
-		self.headers = hdrs
-		self.cookies = cooks
-		self.path = "bla/info.json"
+    def __init__(self, hdrs={}, cooks={}):
+        self.headers = hdrs
+        self.cookies = cooks
+        self.path = "bla/info.json"
 
 class Test_AbstractAuthorizer(unittest.TestCase):
-	
-	def test_strip_empty_fields(self):
-		aa = _AbstractAuthorizer({})
-		self.assertEqual(aa._strip_empty_fields({"a": "", "b": 0, "c": False}), {})
 
-	def test_is_protected_is_notimplementederror(self):
-		aa = _AbstractAuthorizer({})
-		with pytest.raises(NotImplementedError):
-			aa.is_protected(info={})
+    def test_strip_empty_fields(self):
+        aa = _AbstractAuthorizer({})
+        self.assertEqual(aa._strip_empty_fields({"a": "", "b": 0, "c": False}), {})
 
-	def test_get_services_info_is_notimplementederror(self):
-		aa = _AbstractAuthorizer({})
-		with pytest.raises(NotImplementedError):
-			aa.get_services_info(info={})
+    def test_is_protected_is_notimplementederror(self):
+        aa = _AbstractAuthorizer({})
+        with pytest.raises(NotImplementedError):
+            aa.is_protected(info={})
 
-	def test_is_authorized_is_notimplementederror(self):
-		aa = _AbstractAuthorizer({})
-		with pytest.raises(NotImplementedError):
-			aa.is_authorized(info={}, request=None)
+    def test_get_services_info_is_notimplementederror(self):
+        aa = _AbstractAuthorizer({})
+        with pytest.raises(NotImplementedError):
+            aa.get_services_info(info={})
+
+    def test_is_authorized_is_notimplementederror(self):
+        aa = _AbstractAuthorizer({})
+        with pytest.raises(NotImplementedError):
+            aa.is_authorized(info={}, request=None)
 
 
 # This is mostly pointless, as the values returned are static
 class Test_NullAuthorizer(unittest.TestCase):
 
-	def setUp(self):
-		ident = "test"
-		fp = "img/test.png"
-		fmt = "png"
-		self.authorizer = NullAuthorizer({})
-		self.info = ImageInfo(None, ident, fp, fmt)
-		self.request = MockRequest()
+    def setUp(self):
+        ident = "test"
+        fp = "img/test.png"
+        fmt = "png"
+        self.authorizer = NullAuthorizer({})
+        self.info = ImageInfo(None, ident, fp, fmt)
+        self.request = MockRequest()
 
-	def test_is_protected(self):
-		self.assertEqual(self.authorizer.is_protected(self.info), False)
+    def test_is_protected(self):
+        self.assertEqual(self.authorizer.is_protected(self.info), False)
 
-	def test_is_authorized(self):
-		authd = self.authorizer.is_authorized(self.info, self.request)
-		self.assertEqual(authd, {"status": "ok"})
+    def test_is_authorized(self):
+        authd = self.authorizer.is_authorized(self.info, self.request)
+        self.assertEqual(authd, {"status": "ok"})
 
-	def test_get_services_info(self):
-		svcs = self.authorizer.get_services_info(self.info)
-		self.assertEqual(svcs, {})		
+    def test_get_services_info(self):
+        svcs = self.authorizer.get_services_info(self.info)
+        self.assertEqual(svcs, {})
 
 
 # This is also mostly pointless, as the values returned are static
 class Test_NooneAuthorizer(unittest.TestCase):
 
-	def setUp(self):
-		ident = "test"
-		fp = "img/test.png"
-		fmt = "png"
-		self.authorizer = NooneAuthorizer({})
-		self.info = ImageInfo(None, ident, fp, fmt)
-		self.request = MockRequest()
+    def setUp(self):
+        ident = "test"
+        fp = "img/test.png"
+        fmt = "png"
+        self.authorizer = NooneAuthorizer({})
+        self.info = ImageInfo(None, ident, fp, fmt)
+        self.request = MockRequest()
 
-	def test_is_protected(self):
-		self.assertEqual(self.authorizer.is_protected(self.info), True)
+    def test_is_protected(self):
+        self.assertEqual(self.authorizer.is_protected(self.info), True)
 
-	def test_is_authorized(self):
-		authd = self.authorizer.is_authorized(self.info, self.request)
-		self.assertEqual(authd, {"status": "deny"})
+    def test_is_authorized(self):
+        authd = self.authorizer.is_authorized(self.info, self.request)
+        self.assertEqual(authd, {"status": "deny"})
 
-	def test_get_services_info(self):
-		svcs = self.authorizer.get_services_info(self.info)
-		self.assertEqual(svcs['service']['profile'], "http://iiif.io/api/auth/1/login")
+    def test_get_services_info(self):
+        svcs = self.authorizer.get_services_info(self.info)
+        self.assertEqual(svcs['service']['profile'], "http://iiif.io/api/auth/1/login")
 
 # This is ever-so-slightly less pointless
 class Test_SingleDegradingAuthorizer(unittest.TestCase):
 
-	def setUp(self):
-		ident = "test"
-		fp = "img/test.png"
-		fmt = "png"
-		self.authorizer = SingleDegradingAuthorizer({})
-		self.badInfo = ImageInfo(None, ident, fp, fmt)
-		self.okayInfo = ImageInfo(None, "67352ccc-d1b0-11e1-89ae-279075081939.jp2",\
-			"img/67352ccc-d1b0-11e1-89ae-279075081939.jp2", "jp2")
-		self.request = MockRequest()
+    def setUp(self):
+        ident = "test"
+        fp = "img/test.png"
+        fmt = "png"
+        self.authorizer = SingleDegradingAuthorizer({})
+        self.badInfo = ImageInfo(None, ident, fp, fmt)
+        self.okayInfo = ImageInfo(None, "67352ccc-d1b0-11e1-89ae-279075081939.jp2",\
+            "img/67352ccc-d1b0-11e1-89ae-279075081939.jp2", "jp2")
+        self.request = MockRequest()
 
-	def test_is_protected(self):
-		self.assertEqual(self.authorizer.is_protected(self.badInfo), True)
-		self.assertEqual(self.authorizer.is_protected(self.okayInfo), False)
+    def test_is_protected(self):
+        self.assertEqual(self.authorizer.is_protected(self.badInfo), True)
+        self.assertEqual(self.authorizer.is_protected(self.okayInfo), False)
 
-	def test_is_authorized(self):
-		authd = self.authorizer.is_authorized(self.badInfo, self.request)
-		self.assertEqual(authd['status'], "redirect")
+    def test_is_authorized(self):
+        authd = self.authorizer.is_authorized(self.badInfo, self.request)
+        self.assertEqual(authd['status'], "redirect")
 
-	def test_get_services_info(self):
-		svcs = self.authorizer.get_services_info(self.badInfo)
-		self.assertEqual(svcs['service']['profile'], "http://iiif.io/api/auth/1/login")
-		svcs = self.authorizer.get_services_info(self.okayInfo)
-		self.assertEqual(svcs['service']['profile'], "http://iiif.io/api/auth/1/login")
+    def test_get_services_info(self):
+        svcs = self.authorizer.get_services_info(self.badInfo)
+        self.assertEqual(svcs['service']['profile'], "http://iiif.io/api/auth/1/login")
+        svcs = self.authorizer.get_services_info(self.okayInfo)
+        self.assertEqual(svcs['service']['profile'], "http://iiif.io/api/auth/1/login")
 
 # And this is actually useful
 class Test_RulesAuthorizer(unittest.TestCase):
 
-	def setUp(self):
-		ident = "test"
-		fp = "img/test.png"
-		fmt = "png"
+    def setUp(self):
+        ident = "test"
+        fp = "img/test.png"
+        fmt = "png"
 
-		self.authorizer = RulesAuthorizer(
-			{"cookie_secret": "4rakTQJDyhaYgoew802q78pNnsXR7ClvbYtAF1YC87o=",
-			"token_secret": "hyQijpEEe9z1OB9NOkHvmSA4lC1B4lu1n80bKNx0Uz0=",
-			"salt": "4rakTQJD4lC1B4lu"})
-		self.badInfo = ImageInfo(None, ident, fp, fmt)		
-		self.okayInfo = ImageInfo(None, "67352ccc-d1b0-11e1-89ae-279075081939.jp2",\
-			"img/67352ccc-d1b0-11e1-89ae-279075081939.jp2", "jp2")
+        self.authorizer = RulesAuthorizer(
+            {"cookie_secret": "4rakTQJDyhaYgoew802q78pNnsXR7ClvbYtAF1YC87o=",
+            "token_secret": "hyQijpEEe9z1OB9NOkHvmSA4lC1B4lu1n80bKNx0Uz0=",
+            "salt": "4rakTQJD4lC1B4lu"})
+        self.badInfo = ImageInfo(None, ident, fp, fmt)
+        self.okayInfo = ImageInfo(None, "67352ccc-d1b0-11e1-89ae-279075081939.jp2",\
+            "img/67352ccc-d1b0-11e1-89ae-279075081939.jp2", "jp2")
 
-		self.origin = "localhost"
-		# role to get access is "test"
-		# en/decryption defaults to return the plain text
-		self.emptyRequest = MockRequest()
+        self.origin = "localhost"
+        # role to get access is "test"
+        # en/decryption defaults to return the plain text
+        self.emptyRequest = MockRequest()
 
-		secret = "%s-%s" % (self.authorizer.token_secret, self.origin)        
-		key = base64.urlsafe_b64encode(self.authorizer.kdf().derive(secret))
-		self.token_fernet = Fernet(key)
-		tv = self.token_fernet.encrypt("localhost|test")
-		jwt_tv = jwt.encode({"sub": "test"}, secret, algorithm='HS256')
-		jwt_tv_roles = jwt.encode({"roles": ['test']}, secret, algorithm='HS256')
+        secret = "%s-%s" % (self.authorizer.token_secret, self.origin)
+        key = base64.urlsafe_b64encode(self.authorizer.kdf().derive(secret))
+        self.token_fernet = Fernet(key)
+        tv = self.token_fernet.encrypt("localhost|test")
+        jwt_tv = jwt.encode({"sub": "test"}, secret, algorithm='HS256')
+        jwt_tv_roles = jwt.encode({"roles": ['test']}, secret, algorithm='HS256')
 
-		secret = "%s-%s" % (self.authorizer.cookie_secret, self.origin)        
-		key = base64.urlsafe_b64encode(self.authorizer.kdf().derive(secret))
-		self.cookie_fernet = Fernet(key)
-		cv = self.cookie_fernet.encrypt("localhost|test")
-		jwt_cv = jwt.encode({"sub": "test"}, secret, algorithm='HS256')
-		jwt_cv_roles = jwt.encode({"roles": ['test']}, secret, algorithm='HS256')
+        secret = "%s-%s" % (self.authorizer.cookie_secret, self.origin)
+        key = base64.urlsafe_b64encode(self.authorizer.kdf().derive(secret))
+        self.cookie_fernet = Fernet(key)
+        cv = self.cookie_fernet.encrypt("localhost|test")
+        jwt_cv = jwt.encode({"sub": "test"}, secret, algorithm='HS256')
+        jwt_cv_roles = jwt.encode({"roles": ['test']}, secret, algorithm='HS256')
 
-		self.tokenRequest = MockRequest(hdrs={"Authorization": "Bearer %s" % tv, "origin": self.origin})
-		self.cookieRequest = MockRequest(hdrs={"origin": self.origin}, cooks={'iiif_access_cookie': cv})
-		self.cookieRequest.path = ".../default.jpg"
+        self.tokenRequest = MockRequest(hdrs={"Authorization": "Bearer %s" % tv, "origin": self.origin})
+        self.cookieRequest = MockRequest(hdrs={"origin": self.origin}, cooks={'iiif_access_cookie': cv})
+        self.cookieRequest.path = ".../default.jpg"
 
-		self.jwtTokenRequest = MockRequest(hdrs={"Authorization": "Bearer %s" % jwt_tv, "origin": self.origin}) 
-		self.jwtCookieRequest = MockRequest(hdrs={"origin": self.origin}, cooks={'iiif_access_cookie': jwt_cv})
-		self.jwtCookieRequest.path = ".../default.jpg"
-
-
-	def test_basic_origin(self):
-
-		tests = {"http://www.foobar.com/": "foobar.com",
-			"https://www.foobar.com": "foobar.com",
-			"http://foobar.com/": "foobar.com",
-			"http://foobar.com/baz": "foobar.com",
-			"http://foobar.co.uk/": "foobar.co.uk",
-			"http://www.foobar.co.uk": "foobar.co.uk",
-			"http://www.foobar.co.uk/baz": "foobar.co.uk",
-			"http://foobar.com:80/": "foobar.com",
-			"http://localhost:5004/": "localhost",
-			"http://10.0.0.1/": "10.0.0.1",
-			"https://x.y.z.foo.com": "foo.com",
-			"http://x.y.z.foo.co.uk": "foo.co.uk",
-			"www.foobar.com": "foobar.com",
-			"localhost.localdomain": "localhost.localdomain",
-			"x.y.z.foo.co.uk": "foo.co.uk"
-			}
-
-		for (test, expect) in tests.items():
-			self.assertEqual(self.authorizer.basic_origin(test), expect)
-
-	def test_is_protected(self):
-		self.badInfo.auth_rules = {"allowed": ["test"]}
-		self.assertEqual(self.authorizer.is_protected(self.badInfo), True)
-		self.assertEqual(self.authorizer.is_protected(self.okayInfo), False)
-
-	def test_is_authorized(self):
-
-		# Set use_jwt to False
-		self.authorizer.use_jwt = False
-
-		# No auth rules should pass for all
-		authd = self.authorizer.is_authorized(self.okayInfo, self.emptyRequest)	
-		self.assertEqual(authd['status'], "ok")
-		authd = self.authorizer.is_authorized(self.okayInfo, self.tokenRequest)			
-		self.assertEqual(authd['status'], "ok")
-		authd = self.authorizer.is_authorized(self.okayInfo, self.cookieRequest)			
-		self.assertEqual(authd['status'], "ok")
-
-		# Set allowed role of "test"
-		# Should fail for empty, pass for cookie/token
-		self.badInfo.auth_rules = {"allowed": ["test"]}
-		authd = self.authorizer.is_authorized(self.badInfo, self.emptyRequest)
-		self.assertEqual(authd['status'], "deny")
-		authd = self.authorizer.is_authorized(self.badInfo, self.tokenRequest)
-		self.assertEqual(authd['status'], "ok")
-		authd = self.authorizer.is_authorized(self.badInfo, self.cookieRequest)		
-		self.assertEqual(authd['status'], "ok")
-
-		# Set allowed role of "!test"
-		# Should fail for all, as test != !test
-		self.badInfo.auth_rules = {"allowed": ["!test"]}
-		authd = self.authorizer.is_authorized(self.badInfo, self.emptyRequest)
-		self.assertEqual(authd['status'], "deny")
-		authd = self.authorizer.is_authorized(self.badInfo, self.tokenRequest)
-		self.assertEqual(authd['status'], "deny")
-		authd = self.authorizer.is_authorized(self.badInfo, self.cookieRequest)		
-		self.assertEqual(authd['status'], "deny")		
+        self.jwtTokenRequest = MockRequest(hdrs={"Authorization": "Bearer %s" % jwt_tv, "origin": self.origin})
+        self.jwtCookieRequest = MockRequest(hdrs={"origin": self.origin}, cooks={'iiif_access_cookie': jwt_cv})
+        self.jwtCookieRequest.path = ".../default.jpg"
 
 
-		# Set a degraded tier
-		# Should redirect for empty, pass for cookie/token
-		self.badInfo.auth_rules = {"allowed": ["test"], "tiers": 
-			[{"identifier":"http://localhost:5004/"+self.okayInfo.ident}]}
-		authd = self.authorizer.is_authorized(self.badInfo, self.emptyRequest)
-		self.assertEqual(authd['status'], "redirect")
-		authd = self.authorizer.is_authorized(self.badInfo, self.tokenRequest)		
-		self.assertEqual(authd['status'], "ok")
-		authd = self.authorizer.is_authorized(self.badInfo, self.cookieRequest)		
-		self.assertEqual(authd['status'], "ok")
+    def test_basic_origin(self):
 
-	def test_is_authorized_jwt(self):
+        tests = {"http://www.foobar.com/": "foobar.com",
+            "https://www.foobar.com": "foobar.com",
+            "http://foobar.com/": "foobar.com",
+            "http://foobar.com/baz": "foobar.com",
+            "http://foobar.co.uk/": "foobar.co.uk",
+            "http://www.foobar.co.uk": "foobar.co.uk",
+            "http://www.foobar.co.uk/baz": "foobar.co.uk",
+            "http://foobar.com:80/": "foobar.com",
+            "http://localhost:5004/": "localhost",
+            "http://10.0.0.1/": "10.0.0.1",
+            "https://x.y.z.foo.com": "foo.com",
+            "http://x.y.z.foo.co.uk": "foo.co.uk",
+            "www.foobar.com": "foobar.com",
+            "localhost.localdomain": "localhost.localdomain",
+            "x.y.z.foo.co.uk": "foo.co.uk"
+            }
 
-		# Set use_jwt to True
-		self.authorizer.use_jwt = True
+        for (test, expect) in tests.items():
+            self.assertEqual(self.authorizer.basic_origin(test), expect)
 
-		# No auth rules should still pass for all
-		authd = self.authorizer.is_authorized(self.okayInfo, self.emptyRequest)	
-		self.assertEqual(authd['status'], "ok")
-		authd = self.authorizer.is_authorized(self.okayInfo, self.jwtTokenRequest)			
-		self.assertEqual(authd['status'], "ok")
-		authd = self.authorizer.is_authorized(self.okayInfo, self.jwtCookieRequest)			
-		self.assertEqual(authd['status'], "ok")
+    def test_is_protected(self):
+        self.badInfo.auth_rules = {"allowed": ["test"]}
+        self.assertEqual(self.authorizer.is_protected(self.badInfo), True)
+        self.assertEqual(self.authorizer.is_protected(self.okayInfo), False)
 
-		# Set allowed role of "test"
-		# Should fail for empty, pass for cookie/token
-		self.badInfo.auth_rules = {"allowed": ["test"]}
-		authd = self.authorizer.is_authorized(self.badInfo, self.emptyRequest)
-		self.assertEqual(authd['status'], "deny")
-		authd = self.authorizer.is_authorized(self.badInfo, self.jwtTokenRequest)
-		self.assertEqual(authd['status'], "ok")
-		authd = self.authorizer.is_authorized(self.badInfo, self.jwtCookieRequest)		
-		self.assertEqual(authd['status'], "ok")
+    def test_is_authorized(self):
 
-		# Set allowed role of "!test"
-		# Should fail for all, as test != !test
-		self.badInfo.auth_rules = {"allowed": ["!test"]}
-		authd = self.authorizer.is_authorized(self.badInfo, self.emptyRequest)
-		self.assertEqual(authd['status'], "deny")
-		authd = self.authorizer.is_authorized(self.badInfo, self.jwtTokenRequest)
-		self.assertEqual(authd['status'], "deny")
-		authd = self.authorizer.is_authorized(self.badInfo, self.jwtCookieRequest)		
-		self.assertEqual(authd['status'], "deny")		
+        # Set use_jwt to False
+        self.authorizer.use_jwt = False
 
-		# Set a degraded tier
-		# Should redirect for empty, pass for cookie/token
-		self.badInfo.auth_rules = {"allowed": ["test"], "tiers": 
-			[{"identifier":"http://localhost:5004/"+self.okayInfo.ident}]}
-		authd = self.authorizer.is_authorized(self.badInfo, self.emptyRequest)
-		self.assertEqual(authd['status'], "redirect")
-		authd = self.authorizer.is_authorized(self.badInfo, self.jwtTokenRequest)		
-		self.assertEqual(authd['status'], "ok")
-		authd = self.authorizer.is_authorized(self.badInfo, self.jwtCookieRequest)		
-		self.assertEqual(authd['status'], "ok")
+        # No auth rules should pass for all
+        authd = self.authorizer.is_authorized(self.okayInfo, self.emptyRequest)
+        self.assertEqual(authd['status'], "ok")
+        authd = self.authorizer.is_authorized(self.okayInfo, self.tokenRequest)
+        self.assertEqual(authd['status'], "ok")
+        authd = self.authorizer.is_authorized(self.okayInfo, self.cookieRequest)
+        self.assertEqual(authd['status'], "ok")
+
+        # Set allowed role of "test"
+        # Should fail for empty, pass for cookie/token
+        self.badInfo.auth_rules = {"allowed": ["test"]}
+        authd = self.authorizer.is_authorized(self.badInfo, self.emptyRequest)
+        self.assertEqual(authd['status'], "deny")
+        authd = self.authorizer.is_authorized(self.badInfo, self.tokenRequest)
+        self.assertEqual(authd['status'], "ok")
+        authd = self.authorizer.is_authorized(self.badInfo, self.cookieRequest)
+        self.assertEqual(authd['status'], "ok")
+
+        # Set allowed role of "!test"
+        # Should fail for all, as test != !test
+        self.badInfo.auth_rules = {"allowed": ["!test"]}
+        authd = self.authorizer.is_authorized(self.badInfo, self.emptyRequest)
+        self.assertEqual(authd['status'], "deny")
+        authd = self.authorizer.is_authorized(self.badInfo, self.tokenRequest)
+        self.assertEqual(authd['status'], "deny")
+        authd = self.authorizer.is_authorized(self.badInfo, self.cookieRequest)
+        self.assertEqual(authd['status'], "deny")
 
 
-	def test_get_services_info(self):
+        # Set a degraded tier
+        # Should redirect for empty, pass for cookie/token
+        self.badInfo.auth_rules = {"allowed": ["test"], "tiers":
+            [{"identifier":"http://localhost:5004/"+self.okayInfo.ident}]}
+        authd = self.authorizer.is_authorized(self.badInfo, self.emptyRequest)
+        self.assertEqual(authd['status'], "redirect")
+        authd = self.authorizer.is_authorized(self.badInfo, self.tokenRequest)
+        self.assertEqual(authd['status'], "ok")
+        authd = self.authorizer.is_authorized(self.badInfo, self.cookieRequest)
+        self.assertEqual(authd['status'], "ok")
 
-		self.authorizer.cookie_service = "http://localhost:8000/cookie"
+    def test_is_authorized_jwt(self):
 
-		self.badInfo.auth_rules = {"allowed":["test"],"extraInfo": {
-			"service": {
-				"@context": "http://iiif.io/api/auth/1/context.json", 
-				"@id": "http://localhost:8000/cookie",
-				"profile": "http://iiif.io/api/auth/1/login"}
-			}}
-		svcs = self.authorizer.get_services_info(self.badInfo)
-		self.assertEqual(svcs['service']['profile'], "http://iiif.io/api/auth/1/login")
+        # Set use_jwt to True
+        self.authorizer.use_jwt = True
+
+        # No auth rules should still pass for all
+        authd = self.authorizer.is_authorized(self.okayInfo, self.emptyRequest)
+        self.assertEqual(authd['status'], "ok")
+        authd = self.authorizer.is_authorized(self.okayInfo, self.jwtTokenRequest)
+        self.assertEqual(authd['status'], "ok")
+        authd = self.authorizer.is_authorized(self.okayInfo, self.jwtCookieRequest)
+        self.assertEqual(authd['status'], "ok")
+
+        # Set allowed role of "test"
+        # Should fail for empty, pass for cookie/token
+        self.badInfo.auth_rules = {"allowed": ["test"]}
+        authd = self.authorizer.is_authorized(self.badInfo, self.emptyRequest)
+        self.assertEqual(authd['status'], "deny")
+        authd = self.authorizer.is_authorized(self.badInfo, self.jwtTokenRequest)
+        self.assertEqual(authd['status'], "ok")
+        authd = self.authorizer.is_authorized(self.badInfo, self.jwtCookieRequest)
+        self.assertEqual(authd['status'], "ok")
+
+        # Set allowed role of "!test"
+        # Should fail for all, as test != !test
+        self.badInfo.auth_rules = {"allowed": ["!test"]}
+        authd = self.authorizer.is_authorized(self.badInfo, self.emptyRequest)
+        self.assertEqual(authd['status'], "deny")
+        authd = self.authorizer.is_authorized(self.badInfo, self.jwtTokenRequest)
+        self.assertEqual(authd['status'], "deny")
+        authd = self.authorizer.is_authorized(self.badInfo, self.jwtCookieRequest)
+        self.assertEqual(authd['status'], "deny")
+
+        # Set a degraded tier
+        # Should redirect for empty, pass for cookie/token
+        self.badInfo.auth_rules = {"allowed": ["test"], "tiers":
+            [{"identifier":"http://localhost:5004/"+self.okayInfo.ident}]}
+        authd = self.authorizer.is_authorized(self.badInfo, self.emptyRequest)
+        self.assertEqual(authd['status'], "redirect")
+        authd = self.authorizer.is_authorized(self.badInfo, self.jwtTokenRequest)
+        self.assertEqual(authd['status'], "ok")
+        authd = self.authorizer.is_authorized(self.badInfo, self.jwtCookieRequest)
+        self.assertEqual(authd['status'], "ok")
+
+
+    def test_get_services_info(self):
+
+        self.authorizer.cookie_service = "http://localhost:8000/cookie"
+
+        self.badInfo.auth_rules = {"allowed":["test"],"extraInfo": {
+            "service": {
+                "@context": "http://iiif.io/api/auth/1/context.json",
+                "@id": "http://localhost:8000/cookie",
+                "profile": "http://iiif.io/api/auth/1/login"}
+            }}
+        svcs = self.authorizer.get_services_info(self.badInfo)
+        self.assertEqual(svcs['service']['profile'], "http://iiif.io/api/auth/1/login")
 
 
 def suite():
-	import unittest
-	test_suites = []
-	test_suites.append(unittest.makeSuite(Test_AbstractAuthorizer, 'test'))
-	test_suites.append(unittest.makeSuite(Test_NullAuthorizer, 'test'))
-	test_suites.append(unittest.makeSuite(Test_NooneAuthorizer, 'test'))
-	test_suites.append(unittest.makeSuite(Test_SingleDegradingAuthorizer, 'test'))
-	test_suites.append(unittest.makeSuite(Test_RulesAuthorizer, 'test'))
-	test_suite = unittest.TestSuite(test_suites)
-	return test_suite
+    import unittest
+    test_suites = []
+    test_suites.append(unittest.makeSuite(Test_AbstractAuthorizer, 'test'))
+    test_suites.append(unittest.makeSuite(Test_NullAuthorizer, 'test'))
+    test_suites.append(unittest.makeSuite(Test_NooneAuthorizer, 'test'))
+    test_suites.append(unittest.makeSuite(Test_SingleDegradingAuthorizer, 'test'))
+    test_suites.append(unittest.makeSuite(Test_RulesAuthorizer, 'test'))
+    test_suite = unittest.TestSuite(test_suites)
+    return test_suite

--- a/tests/parameters_t.py
+++ b/tests/parameters_t.py
@@ -313,20 +313,20 @@ class TestSizeParameter(_ParameterTest):
         self.assertEquals(sp.force_aspect, False)
         self.assertEquals(sp.mode, PIXEL_MODE)
         self.assertEquals(sp.canonical_uri_value, '125,')
-                self.assertEquals(type(sp.w), int)
-                self.assertEquals(sp.w, 125)
-                self.assertEquals(type(sp.h), int)
-                self.assertEquals(sp.h, 150)
+        self.assertEquals(type(sp.w), int)
+        self.assertEquals(sp.w, 125)
+        self.assertEquals(type(sp.h), int)
+        self.assertEquals(sp.h, 150)
 
-        def test_tiny_image(self):
+    def test_tiny_image(self):
         info = self._get_info_long_x()
         rp = RegionParameter('full', info)
         sp = SizeParameter('1,', rp)
         self.assertEquals(sp.force_aspect, False)
         self.assertEquals(sp.mode, PIXEL_MODE)
         self.assertEquals(sp.canonical_uri_value, '1,')
-                self.assertEquals(sp.w, 1)
-                self.assertEquals(sp.h, 1)
+        self.assertEquals(sp.w, 1)
+        self.assertEquals(sp.h, 1)
 
     def test_populate_slots_from_h_only(self):
         # ,h

--- a/tests/parameters_t.py
+++ b/tests/parameters_t.py
@@ -12,8 +12,8 @@ import pytest
 from loris import img_info
 from loris.loris_exception import RequestException, SyntaxException
 from loris.parameters import (
-	DECIMAL_ONE, FULL_MODE, PCT_MODE, PIXEL_MODE,
-	RegionParameter, RotationParameter, SizeParameter,
+    DECIMAL_ONE, FULL_MODE, PCT_MODE, PIXEL_MODE,
+    RegionParameter, RotationParameter, SizeParameter,
 )
 from tests import loris_t
 
@@ -26,466 +26,466 @@ from the `/loris` (not `/loris/loris`) directory.
 """
 
 def build_image_info(width=100, height=100):
-	"""Produces an ``ImageInfo`` object of the given dimensions."""
-	info = img_info.ImageInfo(None)
-	info.width = width
-	info.height = height
-	return info
+    """Produces an ``ImageInfo`` object of the given dimensions."""
+    info = img_info.ImageInfo(None)
+    info.width = width
+    info.height = height
+    return info
 
 
 class _ParameterTest(loris_t.LorisTest):
-	def _get_info_long_y(self):
-		# jp2, y is long dimension
-		fp = self.test_jp2_color_fp
-		fmt = self.test_jp2_color_fmt
-		ident = self.test_jp2_color_id
-		uri = self.test_jp2_color_uri
-		ii = img_info.ImageInfo(self.app, uri, fp, fmt)
-		return ii
+    def _get_info_long_y(self):
+        # jp2, y is long dimension
+        fp = self.test_jp2_color_fp
+        fmt = self.test_jp2_color_fmt
+        ident = self.test_jp2_color_id
+        uri = self.test_jp2_color_uri
+        ii = img_info.ImageInfo(self.app, uri, fp, fmt)
+        return ii
 
-	def _get_info_long_x(self):
-		# jpeg, x is long dimension
-		fp = self.test_jpeg_fp
-		fmt = self.test_jpeg_fmt
-		ident = self.test_jpeg_id
-		uri = self.test_jpeg_uri
-		ii = img_info.ImageInfo(self.app, uri, fp, fmt)
-		return ii
+    def _get_info_long_x(self):
+        # jpeg, x is long dimension
+        fp = self.test_jpeg_fp
+        fmt = self.test_jpeg_fmt
+        ident = self.test_jpeg_id
+        uri = self.test_jpeg_uri
+        ii = img_info.ImageInfo(self.app, uri, fp, fmt)
+        return ii
 
 class TestRegionParameter(_ParameterTest):
-	def test_populate_slots_from_pct(self):
-		info = self._get_info_long_y()
-		rp = RegionParameter('pct:25,25,50,50', info)
-		self.assertEquals(rp.pixel_x, int(info.width*0.25))
-		self.assertEquals(rp.pixel_y, int(info.height*0.25))
-		self.assertEquals(rp.pixel_w, int(info.width*0.50))
-		self.assertEquals(rp.pixel_h, int(info.height*0.50))
-		self.assertEquals(rp.decimal_x, Decimal('0.25'))
-		self.assertEquals(rp.decimal_y, Decimal('0.25'))
-		self.assertEquals(rp.decimal_w, Decimal('0.50'))
-		self.assertEquals(rp.decimal_h, Decimal('0.50'))
+    def test_populate_slots_from_pct(self):
+        info = self._get_info_long_y()
+        rp = RegionParameter('pct:25,25,50,50', info)
+        self.assertEquals(rp.pixel_x, int(info.width*0.25))
+        self.assertEquals(rp.pixel_y, int(info.height*0.25))
+        self.assertEquals(rp.pixel_w, int(info.width*0.50))
+        self.assertEquals(rp.pixel_h, int(info.height*0.50))
+        self.assertEquals(rp.decimal_x, Decimal('0.25'))
+        self.assertEquals(rp.decimal_y, Decimal('0.25'))
+        self.assertEquals(rp.decimal_w, Decimal('0.50'))
+        self.assertEquals(rp.decimal_h, Decimal('0.50'))
 
-	def test_populate_slots_from_pixel(self):
-		info = self._get_info_long_x()
-		rp = RegionParameter('797,900,1594,1600', info)
-		self.assertEquals(rp.pixel_x, 797)
-		self.assertEquals(rp.pixel_y, 900)
-		self.assertEquals(rp.pixel_w, 1594)
-		self.assertEquals(rp.pixel_h, 1600)
-		self.assertEquals(rp.decimal_x, rp.pixel_x / Decimal(str(info.width)))
-		self.assertEquals(rp.decimal_y, rp.pixel_y / Decimal(str(info.height)))
-		self.assertEquals(rp.decimal_w, rp.pixel_w / Decimal(str(info.width)))
-		self.assertEquals(rp.decimal_h, rp.pixel_h / Decimal(str(info.height)))
+    def test_populate_slots_from_pixel(self):
+        info = self._get_info_long_x()
+        rp = RegionParameter('797,900,1594,1600', info)
+        self.assertEquals(rp.pixel_x, 797)
+        self.assertEquals(rp.pixel_y, 900)
+        self.assertEquals(rp.pixel_w, 1594)
+        self.assertEquals(rp.pixel_h, 1600)
+        self.assertEquals(rp.decimal_x, rp.pixel_x / Decimal(str(info.width)))
+        self.assertEquals(rp.decimal_y, rp.pixel_y / Decimal(str(info.height)))
+        self.assertEquals(rp.decimal_w, rp.pixel_w / Decimal(str(info.width)))
+        self.assertEquals(rp.decimal_h, rp.pixel_h / Decimal(str(info.height)))
 
-	def test_square_mode_long_y(self):
-		# 5906 x 7200
-		info = self._get_info_long_y()
-		rp = RegionParameter('square', info)
-		self.assertEquals(rp.pixel_x, 0)
-		self.assertEquals(rp.pixel_y, 647)
-		self.assertEquals(rp.pixel_w, 5906)
-		self.assertEquals(rp.pixel_h, 5906)
+    def test_square_mode_long_y(self):
+        # 5906 x 7200
+        info = self._get_info_long_y()
+        rp = RegionParameter('square', info)
+        self.assertEquals(rp.pixel_x, 0)
+        self.assertEquals(rp.pixel_y, 647)
+        self.assertEquals(rp.pixel_w, 5906)
+        self.assertEquals(rp.pixel_h, 5906)
 
-	def test_square_mode_long_x(self):
-		# 3600 x 2987
-		info = self._get_info_long_x()
-		rp = RegionParameter('square', info)
-		self.assertEquals(rp.pixel_x, 306)
-		self.assertEquals(rp.pixel_y, 0)
-		self.assertEquals(rp.pixel_w, 2987)
-		self.assertEquals(rp.pixel_h, 2987)
+    def test_square_mode_long_x(self):
+        # 3600 x 2987
+        info = self._get_info_long_x()
+        rp = RegionParameter('square', info)
+        self.assertEquals(rp.pixel_x, 306)
+        self.assertEquals(rp.pixel_y, 0)
+        self.assertEquals(rp.pixel_w, 2987)
+        self.assertEquals(rp.pixel_h, 2987)
 
-	def test_recognise_full_mode_if_correct_dimensions(self):
-		info = build_image_info(1500, 800)
-		rp = RegionParameter('0,0,1500,800', info)
-		self.assertEquals(rp.mode, FULL_MODE)
+    def test_recognise_full_mode_if_correct_dimensions(self):
+        info = build_image_info(1500, 800)
+        rp = RegionParameter('0,0,1500,800', info)
+        self.assertEquals(rp.mode, FULL_MODE)
 
-	def test_anything_except_four_coordinates_is_error(self):
-		info = build_image_info()
-		with self.assertRaises(SyntaxException):
-			RegionParameter('pct:100', info)
+    def test_anything_except_four_coordinates_is_error(self):
+        info = build_image_info()
+        with self.assertRaises(SyntaxException):
+            RegionParameter('pct:100', info)
 
-	def test_percentage_greater_than_100_is_error(self):
-		info = build_image_info()
-		with self.assertRaises(RequestException):
-			RegionParameter('pct:150,150,150,150', info)
+    def test_percentage_greater_than_100_is_error(self):
+        info = build_image_info()
+        with self.assertRaises(RequestException):
+            RegionParameter('pct:150,150,150,150', info)
 
-	def test_x_parameter_greater_than_width_is_error(self):
-		info = build_image_info(width=100)
-		with self.assertRaises(RequestException):
-			RegionParameter('200,0,100,100', info)
+    def test_x_parameter_greater_than_width_is_error(self):
+        info = build_image_info(width=100)
+        with self.assertRaises(RequestException):
+            RegionParameter('200,0,100,100', info)
 
-	def test_y_parameter_greater_than_height_is_error(self):
-		info = build_image_info(height=100)
-		with self.assertRaises(RequestException):
-			RegionParameter('0,200,100,100', info)
+    def test_y_parameter_greater_than_height_is_error(self):
+        info = build_image_info(height=100)
+        with self.assertRaises(RequestException):
+            RegionParameter('0,200,100,100', info)
 
-	def test_canonical_uri_value_oob_w_pixel(self):
-		info = self._get_info_long_x() # x is long dimension
-		x = 200
-		offset = 1
-		oob_w = info.width - x + offset
-		rp = RegionParameter('%d,13,%d,17' % (x,oob_w), info)
-		expected_canonical = '%d,13,%d,17' % (x, info.width - x)
-		# Note that the below will need to be changed if decimal precision is
-		# changed (currently 25 places)
-		self.assertEquals(rp.decimal_w, Decimal('0.9444444444444444444444444'))
-		self.assertEquals(rp.canonical_uri_value, expected_canonical)
+    def test_canonical_uri_value_oob_w_pixel(self):
+        info = self._get_info_long_x() # x is long dimension
+        x = 200
+        offset = 1
+        oob_w = info.width - x + offset
+        rp = RegionParameter('%d,13,%d,17' % (x,oob_w), info)
+        expected_canonical = '%d,13,%d,17' % (x, info.width - x)
+        # Note that the below will need to be changed if decimal precision is
+        # changed (currently 25 places)
+        self.assertEquals(rp.decimal_w, Decimal('0.9444444444444444444444444'))
+        self.assertEquals(rp.canonical_uri_value, expected_canonical)
 
-	def test_canonical_uri_value_oob_w_pct(self):
-		info = self._get_info_long_y() # y is long dimension
-		x = 20
-		w = 81
-		rp = RegionParameter('pct:%d,13,%d,27' % (x,w), info)
-		self.assertEquals(rp.decimal_w, Decimal('0.8'))
-		expected_canonical = '1181,936,4725,1944'
-		self.assertEquals(rp.canonical_uri_value, expected_canonical)
+    def test_canonical_uri_value_oob_w_pct(self):
+        info = self._get_info_long_y() # y is long dimension
+        x = 20
+        w = 81
+        rp = RegionParameter('pct:%d,13,%d,27' % (x,w), info)
+        self.assertEquals(rp.decimal_w, Decimal('0.8'))
+        expected_canonical = '1181,936,4725,1944'
+        self.assertEquals(rp.canonical_uri_value, expected_canonical)
 
-	def test_canonical_uri_value_oob_y_pixel(self):
-		info = self._get_info_long_y() # y is long dimension
-		y = 300
-		offset = 1 # request would be this many pixels OOB
-		oob_h = info.height - y + offset
-		rp = RegionParameter('29,%d,31,%d' % (y,oob_h), info)
-		expected_canonical = '29,%d,31,%d' % (y, info.height - y)
-		self.assertEquals(rp.canonical_uri_value, expected_canonical)
+    def test_canonical_uri_value_oob_y_pixel(self):
+        info = self._get_info_long_y() # y is long dimension
+        y = 300
+        offset = 1 # request would be this many pixels OOB
+        oob_h = info.height - y + offset
+        rp = RegionParameter('29,%d,31,%d' % (y,oob_h), info)
+        expected_canonical = '29,%d,31,%d' % (y, info.height - y)
+        self.assertEquals(rp.canonical_uri_value, expected_canonical)
 
-	def test_canonical_uri_value_oob_y_pct(self):
-		info = self._get_info_long_x() # x is long dimension
-		y = 28.3
-		h = 72.2
-		rp = RegionParameter('pct:13,%f,17,%f' % (y,h), info)
-		expected_canonical = '468,845,612,2142'
-		self.assertEquals(rp.canonical_uri_value, expected_canonical)
+    def test_canonical_uri_value_oob_y_pct(self):
+        info = self._get_info_long_x() # x is long dimension
+        y = 28.3
+        h = 72.2
+        rp = RegionParameter('pct:13,%f,17,%f' % (y,h), info)
+        expected_canonical = '468,845,612,2142'
+        self.assertEquals(rp.canonical_uri_value, expected_canonical)
 
-	def test_syntax_exceptions(self):
-		info = self._get_info_long_y()
-		with self.assertRaises(SyntaxException):
-			RegionParameter('n:1,2,3,4', info)
-		with self.assertRaises(SyntaxException):
-			RegionParameter('1,2,3,q', info)
-		with self.assertRaises(SyntaxException):
-			RegionParameter('1,2,3', info)
-		with self.assertRaises(SyntaxException):
-			RegionParameter('something', info)
+    def test_syntax_exceptions(self):
+        info = self._get_info_long_y()
+        with self.assertRaises(SyntaxException):
+            RegionParameter('n:1,2,3,4', info)
+        with self.assertRaises(SyntaxException):
+            RegionParameter('1,2,3,q', info)
+        with self.assertRaises(SyntaxException):
+            RegionParameter('1,2,3', info)
+        with self.assertRaises(SyntaxException):
+            RegionParameter('something', info)
 
-	def test_request_exceptions(self):
-		info = self._get_info_long_y()
-		with self.assertRaises(RequestException):
-			RegionParameter('1,2,0,3', info)
-		with self.assertRaises(RequestException):
-			RegionParameter('1,2,3,0', info)
-		with self.assertRaises(RequestException):
-			RegionParameter('pct:100,2,3,0', info)
+    def test_request_exceptions(self):
+        info = self._get_info_long_y()
+        with self.assertRaises(RequestException):
+            RegionParameter('1,2,0,3', info)
+        with self.assertRaises(RequestException):
+            RegionParameter('1,2,3,0', info)
+        with self.assertRaises(RequestException):
+            RegionParameter('pct:100,2,3,0', info)
 
-	def test_str(self):
-		info = self._get_info_long_y()
-		rp1 = RegionParameter('full', info)
-		self.assertEquals(str(rp1), 'full')
+    def test_str(self):
+        info = self._get_info_long_y()
+        rp1 = RegionParameter('full', info)
+        self.assertEquals(str(rp1), 'full')
 
-		rp2 = RegionParameter('125,15,120,140', info)
-		self.assertEquals(str(rp2), '125,15,120,140')
+        rp2 = RegionParameter('125,15,120,140', info)
+        self.assertEquals(str(rp2), '125,15,120,140')
 
-		rp3 = RegionParameter('pct:41.6,7.5,40,70', info)
-		self.assertEquals(str(rp3), 'pct:41.6,7.5,40,70')
+        rp3 = RegionParameter('pct:41.6,7.5,40,70', info)
+        self.assertEquals(str(rp3), 'pct:41.6,7.5,40,70')
 
-		rp4 = RegionParameter('125,15,200,200', info)
-		self.assertEquals(str(rp4), '125,15,200,200')
+        rp4 = RegionParameter('125,15,200,200', info)
+        self.assertEquals(str(rp4), '125,15,200,200')
 
-		rp5 = RegionParameter('pct:41.6,7.5,66.6,100', info)
-		self.assertEquals(str(rp5), 'pct:41.6,7.5,66.6,100')
+        rp5 = RegionParameter('pct:41.6,7.5,66.6,100', info)
+        self.assertEquals(str(rp5), 'pct:41.6,7.5,66.6,100')
 
 
 class TestSizeParameter(_ParameterTest):
-	def test_exceptions(self):
-		info = self._get_info_long_y()
-		rp = RegionParameter('pct:25,25,75,75', info)
-		with self.assertRaises(SyntaxException):
-			SizeParameter('!25,', rp)
-		with self.assertRaises(SyntaxException):
-			SizeParameter('!25', rp)
-		with self.assertRaises(SyntaxException):
-			SizeParameter('25', rp)
+    def test_exceptions(self):
+        info = self._get_info_long_y()
+        rp = RegionParameter('pct:25,25,75,75', info)
+        with self.assertRaises(SyntaxException):
+            SizeParameter('!25,', rp)
+        with self.assertRaises(SyntaxException):
+            SizeParameter('!25', rp)
+        with self.assertRaises(SyntaxException):
+            SizeParameter('25', rp)
 
-	def test_zero_or_negative_percentage_is_rejected(self):
-		info = build_image_info(100, 100)
-		rp = RegionParameter('full', info)
-		with self.assertRaises(RequestException):
-			SizeParameter('pct:0', rp)
+    def test_zero_or_negative_percentage_is_rejected(self):
+        info = build_image_info(100, 100)
+        rp = RegionParameter('full', info)
+        with self.assertRaises(RequestException):
+            SizeParameter('pct:0', rp)
 
-	def test_very_small_pixel_width_is_positive(self):
-		info = build_image_info(width=1, height=100)
-		rp = RegionParameter('full', info)
-		sp = SizeParameter(',50', rp)
-		self.assertEquals(sp.w, 1)
+    def test_very_small_pixel_width_is_positive(self):
+        info = build_image_info(width=1, height=100)
+        rp = RegionParameter('full', info)
+        sp = SizeParameter(',50', rp)
+        self.assertEquals(sp.w, 1)
 
-	def test_very_small_pixel_height_is_positive(self):
-		info = build_image_info(width=100, height=1)
-		rp = RegionParameter('full', info)
-		sp = SizeParameter('50,', rp)
-		self.assertEquals(sp.h, 1)
+    def test_very_small_pixel_height_is_positive(self):
+        info = build_image_info(width=100, height=1)
+        rp = RegionParameter('full', info)
+        sp = SizeParameter('50,', rp)
+        self.assertEquals(sp.h, 1)
 
-	def test_very_small_percentage_width_is_positive(self):
-		info = build_image_info(width=1, height=100)
-		rp = RegionParameter('full', info)
-		sp = SizeParameter('pct:50', rp)
-		self.assertEquals(sp.w, 1)
+    def test_very_small_percentage_width_is_positive(self):
+        info = build_image_info(width=1, height=100)
+        rp = RegionParameter('full', info)
+        sp = SizeParameter('pct:50', rp)
+        self.assertEquals(sp.w, 1)
 
-	def test_negative_x_percentage_is_rejected(self):
-		info = build_image_info()
-		with self.assertRaises(RequestException):
-			rp = RegionParameter('pct:-5,100,100,100', info)
+    def test_negative_x_percentage_is_rejected(self):
+        info = build_image_info()
+        with self.assertRaises(RequestException):
+            rp = RegionParameter('pct:-5,100,100,100', info)
 
-	def test_negative_y_percentage_is_rejected(self):
-		info = build_image_info()
-		with self.assertRaises(RequestException):
-			rp = RegionParameter('pct:100,-5,100,100', info)
+    def test_negative_y_percentage_is_rejected(self):
+        info = build_image_info()
+        with self.assertRaises(RequestException):
+            rp = RegionParameter('pct:100,-5,100,100', info)
 
-	def test_str_representation(self):
-		info = build_image_info()
-		rp = RegionParameter('full', info)
-		for uri_value in [
-			'full',
-			'pct:50',
-			'50,',
-			',50',
-			'!50,50',
-		]:
-			sp = SizeParameter(uri_value, rp)
-			self.assertEquals(str(sp), uri_value)
+    def test_str_representation(self):
+        info = build_image_info()
+        rp = RegionParameter('full', info)
+        for uri_value in [
+            'full',
+            'pct:50',
+            '50,',
+            ',50',
+            '!50,50',
+        ]:
+            sp = SizeParameter(uri_value, rp)
+            self.assertEquals(str(sp), uri_value)
 
-	def test_very_small_percentage_height_is_positive(self):
-		info = build_image_info(width=100, height=1)
-		rp = RegionParameter('full', info)
-		sp = SizeParameter('pct:50', rp)
-		self.assertEquals(sp.h, 1)
+    def test_very_small_percentage_height_is_positive(self):
+        info = build_image_info(width=100, height=1)
+        rp = RegionParameter('full', info)
+        sp = SizeParameter('pct:50', rp)
+        self.assertEquals(sp.h, 1)
 
-	def test_populate_slots_from_full(self):
-		# full
-		info = self._get_info_long_y()
+    def test_populate_slots_from_full(self):
+        # full
+        info = self._get_info_long_y()
 
-		rp = RegionParameter('full', info)
-		sp = SizeParameter('full',rp)
-		self.assertEquals(sp.force_aspect, False)
-		self.assertEquals(sp.mode, FULL_MODE)
-		self.assertEquals(sp.canonical_uri_value, FULL_MODE)
+        rp = RegionParameter('full', info)
+        sp = SizeParameter('full',rp)
+        self.assertEquals(sp.force_aspect, False)
+        self.assertEquals(sp.mode, FULL_MODE)
+        self.assertEquals(sp.canonical_uri_value, FULL_MODE)
 
-		rp = RegionParameter('256,256,256,256', info)
-		sp = SizeParameter('full',rp)
-		self.assertEquals(sp.force_aspect, False)
-		self.assertEquals(sp.mode, FULL_MODE)
-		self.assertEquals(sp.canonical_uri_value, FULL_MODE)
+        rp = RegionParameter('256,256,256,256', info)
+        sp = SizeParameter('full',rp)
+        self.assertEquals(sp.force_aspect, False)
+        self.assertEquals(sp.mode, FULL_MODE)
+        self.assertEquals(sp.canonical_uri_value, FULL_MODE)
 
-	def test_populate_slots_from_pct(self):
-		# pct:n
-		info = self._get_info_long_y()
+    def test_populate_slots_from_pct(self):
+        # pct:n
+        info = self._get_info_long_y()
 
-		rp = RegionParameter('full', info)
-		sp = SizeParameter('pct:25',rp)
-		self.assertEquals(sp.force_aspect, False)
-		self.assertEquals(sp.mode, PCT_MODE)
-		self.assertEquals(sp.canonical_uri_value, '1476,')
+        rp = RegionParameter('full', info)
+        sp = SizeParameter('pct:25',rp)
+        self.assertEquals(sp.force_aspect, False)
+        self.assertEquals(sp.mode, PCT_MODE)
+        self.assertEquals(sp.canonical_uri_value, '1476,')
 
-		rp = RegionParameter('256,256,256,256', info)
-		sp = SizeParameter('pct:25',rp)
-		self.assertEquals(sp.force_aspect, False)
-		self.assertEquals(sp.mode, PCT_MODE)
-		self.assertEquals(sp.canonical_uri_value, '64,')
+        rp = RegionParameter('256,256,256,256', info)
+        sp = SizeParameter('pct:25',rp)
+        self.assertEquals(sp.force_aspect, False)
+        self.assertEquals(sp.mode, PCT_MODE)
+        self.assertEquals(sp.canonical_uri_value, '64,')
 
-		rp = RegionParameter('pct:0,0,50,50', info)
-		sp = SizeParameter('pct:25',rp)
-		self.assertEquals(sp.force_aspect, False)
-		self.assertEquals(sp.mode, PCT_MODE)
-		self.assertEquals(sp.canonical_uri_value, '738,')
+        rp = RegionParameter('pct:0,0,50,50', info)
+        sp = SizeParameter('pct:25',rp)
+        self.assertEquals(sp.force_aspect, False)
+        self.assertEquals(sp.mode, PCT_MODE)
+        self.assertEquals(sp.canonical_uri_value, '738,')
 
-	def test_populate_slots_from_w_only(self):
-		# w,
-		info = self._get_info_long_y()
+    def test_populate_slots_from_w_only(self):
+        # w,
+        info = self._get_info_long_y()
 
-		rp = RegionParameter('full', info)
-		sp = SizeParameter('180,',rp)
-		self.assertEquals(sp.force_aspect, False)
-		self.assertEquals(sp.mode, PIXEL_MODE)
-		self.assertEquals(sp.canonical_uri_value, '180,')
+        rp = RegionParameter('full', info)
+        sp = SizeParameter('180,',rp)
+        self.assertEquals(sp.force_aspect, False)
+        self.assertEquals(sp.mode, PIXEL_MODE)
+        self.assertEquals(sp.canonical_uri_value, '180,')
 
-		rp = RegionParameter('200,300,500,600', info)
-		sp = SizeParameter('125,',rp)
-		self.assertEquals(sp.force_aspect, False)
-		self.assertEquals(sp.mode, PIXEL_MODE)
-		self.assertEquals(sp.canonical_uri_value, '125,')
+        rp = RegionParameter('200,300,500,600', info)
+        sp = SizeParameter('125,',rp)
+        self.assertEquals(sp.force_aspect, False)
+        self.assertEquals(sp.mode, PIXEL_MODE)
+        self.assertEquals(sp.canonical_uri_value, '125,')
                 self.assertEquals(type(sp.w), int)
                 self.assertEquals(sp.w, 125)
                 self.assertEquals(type(sp.h), int)
                 self.assertEquals(sp.h, 150)
 
         def test_tiny_image(self):
-		info = self._get_info_long_x()
-		rp = RegionParameter('full', info)
-		sp = SizeParameter('1,', rp)
-		self.assertEquals(sp.force_aspect, False)
-		self.assertEquals(sp.mode, PIXEL_MODE)
-		self.assertEquals(sp.canonical_uri_value, '1,')
+        info = self._get_info_long_x()
+        rp = RegionParameter('full', info)
+        sp = SizeParameter('1,', rp)
+        self.assertEquals(sp.force_aspect, False)
+        self.assertEquals(sp.mode, PIXEL_MODE)
+        self.assertEquals(sp.canonical_uri_value, '1,')
                 self.assertEquals(sp.w, 1)
                 self.assertEquals(sp.h, 1)
 
-	def test_populate_slots_from_h_only(self):
-		# ,h
-		info = self._get_info_long_y()
+    def test_populate_slots_from_h_only(self):
+        # ,h
+        info = self._get_info_long_y()
 
-		rp = RegionParameter('full', info)
-		sp = SizeParameter(',90',rp)
-		self.assertEquals(sp.force_aspect, False)
-		self.assertEquals(sp.mode, PIXEL_MODE)
-		self.assertEquals(sp.canonical_uri_value, '73,')
+        rp = RegionParameter('full', info)
+        sp = SizeParameter(',90',rp)
+        self.assertEquals(sp.force_aspect, False)
+        self.assertEquals(sp.mode, PIXEL_MODE)
+        self.assertEquals(sp.canonical_uri_value, '73,')
 
-		rp = RegionParameter('50,290,360,910', info)
-		sp = SizeParameter(',275',rp)
-		self.assertEquals(sp.force_aspect, False)
-		self.assertEquals(sp.mode, PIXEL_MODE)
-		self.assertEquals(sp.canonical_uri_value, '108,')
+        rp = RegionParameter('50,290,360,910', info)
+        sp = SizeParameter(',275',rp)
+        self.assertEquals(sp.force_aspect, False)
+        self.assertEquals(sp.mode, PIXEL_MODE)
+        self.assertEquals(sp.canonical_uri_value, '108,')
 
-	def test_populate_slots_from_wh(self):
-		# w,h
-		info = self._get_info_long_y()
+    def test_populate_slots_from_wh(self):
+        # w,h
+        info = self._get_info_long_y()
 
-		rp = RegionParameter('full', info)
-		sp = SizeParameter('48,48',rp)
-		self.assertEquals(sp.force_aspect, True)
-		self.assertEquals(sp.mode, PIXEL_MODE)
-		self.assertEquals(sp.canonical_uri_value, '48,48')
+        rp = RegionParameter('full', info)
+        sp = SizeParameter('48,48',rp)
+        self.assertEquals(sp.force_aspect, True)
+        self.assertEquals(sp.mode, PIXEL_MODE)
+        self.assertEquals(sp.canonical_uri_value, '48,48')
 
-		rp = RegionParameter('15,16,23,42', info)
-		sp = SizeParameter('60,60',rp) # upsample!
-		self.assertEquals(sp.force_aspect, True)
-		self.assertEquals(sp.mode, PIXEL_MODE)
-		self.assertEquals(sp.canonical_uri_value, '60,60')
+        rp = RegionParameter('15,16,23,42', info)
+        sp = SizeParameter('60,60',rp) # upsample!
+        self.assertEquals(sp.force_aspect, True)
+        self.assertEquals(sp.mode, PIXEL_MODE)
+        self.assertEquals(sp.canonical_uri_value, '60,60')
 
-	def test_populate_slots_from_bang_wh(self):
-		# !w,h
-		info = self._get_info_long_y()
+    def test_populate_slots_from_bang_wh(self):
+        # !w,h
+        info = self._get_info_long_y()
 
-		rp = RegionParameter('full', info)
-		sp = SizeParameter('!120,140',rp)
-		self.assertEquals(sp.force_aspect, False)
-		self.assertEquals(sp.mode, PIXEL_MODE)
-		self.assertEquals(sp.canonical_uri_value, '114,')
+        rp = RegionParameter('full', info)
+        sp = SizeParameter('!120,140',rp)
+        self.assertEquals(sp.force_aspect, False)
+        self.assertEquals(sp.mode, PIXEL_MODE)
+        self.assertEquals(sp.canonical_uri_value, '114,')
 
-		rp = RegionParameter('0,0,125,160', info)
-		sp = SizeParameter('!120,140',rp,)
-		self.assertEquals(sp.force_aspect, False)
-		self.assertEquals(sp.mode, PIXEL_MODE)
-		self.assertEquals(sp.canonical_uri_value, '109,')
+        rp = RegionParameter('0,0,125,160', info)
+        sp = SizeParameter('!120,140',rp,)
+        self.assertEquals(sp.force_aspect, False)
+        self.assertEquals(sp.mode, PIXEL_MODE)
+        self.assertEquals(sp.canonical_uri_value, '109,')
 
-		rp = RegionParameter('0,0,125,160', info)
-		sp = SizeParameter('!130,140',rp)
-		self.assertEquals(sp.force_aspect, False)
-		self.assertEquals(sp.mode, PIXEL_MODE)
-		self.assertEquals(sp.canonical_uri_value, '109,')
+        rp = RegionParameter('0,0,125,160', info)
+        sp = SizeParameter('!130,140',rp)
+        self.assertEquals(sp.force_aspect, False)
+        self.assertEquals(sp.mode, PIXEL_MODE)
+        self.assertEquals(sp.canonical_uri_value, '109,')
 
-		rp = RegionParameter('50,80,140,160', info)
-		sp = SizeParameter('!130,180',rp)
-		self.assertEquals(sp.force_aspect, False)
-		self.assertEquals(sp.mode, PIXEL_MODE)
-		self.assertEquals(sp.canonical_uri_value, '130,')
+        rp = RegionParameter('50,80,140,160', info)
+        sp = SizeParameter('!130,180',rp)
+        self.assertEquals(sp.force_aspect, False)
+        self.assertEquals(sp.mode, PIXEL_MODE)
+        self.assertEquals(sp.canonical_uri_value, '130,')
 
-		rp = RegionParameter('50,80,140,160', info)
-		sp = SizeParameter('!145,165',rp)
-		self.assertEquals(sp.force_aspect, False)
-		self.assertEquals(sp.mode, PIXEL_MODE)
-		self.assertEquals(sp.canonical_uri_value, '144,')
+        rp = RegionParameter('50,80,140,160', info)
+        sp = SizeParameter('!145,165',rp)
+        self.assertEquals(sp.force_aspect, False)
+        self.assertEquals(sp.mode, PIXEL_MODE)
+        self.assertEquals(sp.canonical_uri_value, '144,')
 
-		rp = RegionParameter('50,80,140,180', info)
-		sp = SizeParameter('!145,185',rp)
-		self.assertEquals(sp.force_aspect, False)
-		self.assertEquals(sp.mode, PIXEL_MODE)
-		self.assertEquals(sp.canonical_uri_value, '143,')
+        rp = RegionParameter('50,80,140,180', info)
+        sp = SizeParameter('!145,185',rp)
+        self.assertEquals(sp.force_aspect, False)
+        self.assertEquals(sp.mode, PIXEL_MODE)
+        self.assertEquals(sp.canonical_uri_value, '143,')
 
-	def test_zero_width_or_height_is_rejected(self):
-		info = build_image_info()
-		rp = RegionParameter('full', info)
-		with pytest.raises(RequestException):
-			SizeParameter('0,', rp)
-		with pytest.raises(RequestException):
-			SizeParameter(',0', rp)
-		with pytest.raises(RequestException):
-			SizeParameter('0,0', rp)
+    def test_zero_width_or_height_is_rejected(self):
+        info = build_image_info()
+        rp = RegionParameter('full', info)
+        with pytest.raises(RequestException):
+            SizeParameter('0,', rp)
+        with pytest.raises(RequestException):
+            SizeParameter(',0', rp)
+        with pytest.raises(RequestException):
+            SizeParameter('0,0', rp)
 
-	@given(text(alphabet='0123456789.,!'))
-	def test_parsing_parameter_either_passes_or_is_exception(self, uri_value):
-		info = build_image_info()
-		rp = RegionParameter('full', info)
-		try:
-			SizeParameter(uri_value, rp)
-		except (RequestException, SyntaxException):
-			pass
+    @given(text(alphabet='0123456789.,!'))
+    def test_parsing_parameter_either_passes_or_is_exception(self, uri_value):
+        info = build_image_info()
+        rp = RegionParameter('full', info)
+        try:
+            SizeParameter(uri_value, rp)
+        except (RequestException, SyntaxException):
+            pass
 
 
 class TestRotationParameter(_ParameterTest):
-	def test_exceptions(self):
-		with self.assertRaises(SyntaxException):
-			rp = RotationParameter('a')
-		with self.assertRaises(SyntaxException):
-			rp = RotationParameter('361')
-		with self.assertRaises(SyntaxException):
-			rp = RotationParameter('-1')
-		with self.assertRaises(SyntaxException):
-			rp = RotationParameter('!-1')
-		with self.assertRaises(SyntaxException):
-			rp = RotationParameter('!361')
-		with self.assertRaises(SyntaxException):
-			rp = RotationParameter('-0.1')
-		with self.assertRaises(SyntaxException):
-			rp = RotationParameter('1.3.6')
-		with self.assertRaises(SyntaxException):
-			rp = RotationParameter('!2.7.13')
-		with self.assertRaises(SyntaxException):
-			rp = RotationParameter('.')
-		with self.assertRaises(SyntaxException):
-			rp = RotationParameter('.0.')
+    def test_exceptions(self):
+        with self.assertRaises(SyntaxException):
+            rp = RotationParameter('a')
+        with self.assertRaises(SyntaxException):
+            rp = RotationParameter('361')
+        with self.assertRaises(SyntaxException):
+            rp = RotationParameter('-1')
+        with self.assertRaises(SyntaxException):
+            rp = RotationParameter('!-1')
+        with self.assertRaises(SyntaxException):
+            rp = RotationParameter('!361')
+        with self.assertRaises(SyntaxException):
+            rp = RotationParameter('-0.1')
+        with self.assertRaises(SyntaxException):
+            rp = RotationParameter('1.3.6')
+        with self.assertRaises(SyntaxException):
+            rp = RotationParameter('!2.7.13')
+        with self.assertRaises(SyntaxException):
+            rp = RotationParameter('.')
+        with self.assertRaises(SyntaxException):
+            rp = RotationParameter('.0.')
 
-	@given(text(alphabet='0123456789.!'))
-	def test_parsing_parameter_either_passes_or_is_syntaxexception(self, xs):
-	    try:
-	        RotationParameter(xs)
-	    except SyntaxException:
-	        pass
+    @given(text(alphabet='0123456789.!'))
+    def test_parsing_parameter_either_passes_or_is_syntaxexception(self, xs):
+        try:
+            RotationParameter(xs)
+        except SyntaxException:
+            pass
 
-	def test_uri_value(self):
-		rp = RotationParameter('0')
-		self.assertEquals(rp.rotation, '0')
+    def test_uri_value(self):
+        rp = RotationParameter('0')
+        self.assertEquals(rp.rotation, '0')
 
-		rp = RotationParameter('46')
-		self.assertEquals(rp.rotation, '46')
+        rp = RotationParameter('46')
+        self.assertEquals(rp.rotation, '46')
 
-		rp = RotationParameter('180')
-		self.assertEquals(rp.rotation, '180')
+        rp = RotationParameter('180')
+        self.assertEquals(rp.rotation, '180')
 
-	def test_mirroring(self):
-		rp = RotationParameter('180')
-		self.assertFalse(rp.mirror)
+    def test_mirroring(self):
+        rp = RotationParameter('180')
+        self.assertFalse(rp.mirror)
 
-		rp = RotationParameter('!180')
-		self.assertTrue(rp.mirror)
+        rp = RotationParameter('!180')
+        self.assertTrue(rp.mirror)
 
-	def test_c14n(self):
-		rp = RotationParameter('42.10')
-		self.assertEquals(rp.canonical_uri_value, '42.1')
+    def test_c14n(self):
+        rp = RotationParameter('42.10')
+        self.assertEquals(rp.canonical_uri_value, '42.1')
 
-		rp = RotationParameter('180.0')
-		self.assertEquals(rp.canonical_uri_value, '180')
+        rp = RotationParameter('180.0')
+        self.assertEquals(rp.canonical_uri_value, '180')
 
-		rp = RotationParameter('!180.0')
-		self.assertEquals(rp.canonical_uri_value, '!180')
+        rp = RotationParameter('!180.0')
+        self.assertEquals(rp.canonical_uri_value, '!180')
 
-		rp = RotationParameter('!180.10')
-		self.assertEquals(rp.canonical_uri_value, '!180.1')
+        rp = RotationParameter('!180.10')
+        self.assertEquals(rp.canonical_uri_value, '!180.1')
 
 
 def suite():
-	import unittest
-	test_suites = []
-	test_suites.append(unittest.makeSuite(TestRegionParameter, 'test'))
-	test_suites.append(unittest.makeSuite(TestSizeParameter, 'test'))
-	test_suites.append(unittest.makeSuite(TestRotationParameter, 'test'))
-	test_suite = unittest.TestSuite(test_suites)
-	return test_suite
+    import unittest
+    test_suites = []
+    test_suites.append(unittest.makeSuite(TestRegionParameter, 'test'))
+    test_suites.append(unittest.makeSuite(TestSizeParameter, 'test'))
+    test_suites.append(unittest.makeSuite(TestRotationParameter, 'test'))
+    test_suite = unittest.TestSuite(test_suites)
+    return test_suite


### PR DESCRIPTION
In Python 3, mixing tabs and spaces is a SyntaxError. Loris had a mixture of tabs and spaces used for indentation, so I swapped them all to spaces and committed the result.

Related: #324.