### PR TITLE
More human-readable errors around the extraInfo parameter on ImageInfo

### DIFF
--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -78,8 +78,18 @@ class ImageInfo(object):
         self.license = None
         self.service = {}
         self.auth_rules = extra
-        for (k,v) in extra.get('extraInfo', {}).items():
-            setattr(self, k, v)
+
+        # The extraInfo parameter can be used to override specific attributes.
+        # If there are extra attributes, drop an error.
+        bad_attrs = []
+        for (k, v) in extra.get('extraInfo', {}).items():
+            try:
+                setattr(self, k, v)
+            except AttributeError:
+                bad_attrs.append(k)
+        if bad_attrs:
+            message = "Invalid parameters in extraInfo: %s" % ', '.join(bad_attrs)
+            raise ImageInfoException(http_status=500, message=message)
 
         # If constructed from JSON, the pixel info will already be processed
         if app:


### PR DESCRIPTION
Resolves #369.

This catches the AttributeError, and rethrows it as an ImageInfoException with an error message that highlights the issue. Plus some tests, because previously this code path was untested.