### PR TITLE
Add Travis CI runs with Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ addons:
 
 language: python
 
+python:
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
+
 matrix:
   include:
     - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,14 @@ addons:
 
 language: python
 
-python:
- - "2.7"
+matrix:
+  include:
+    - python: 2.7
+
+  allow_failures:
+    - python: 3.4
+    - python: 3.5
+    - python: 3.6
 
 install:
  - pip install -r requirements_test.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ python:
   - 3.6
 
 matrix:
-  include:
-    - python: 2.7
-
   allow_failures:
     - python: 3.4
     - python: 3.5


### PR DESCRIPTION
This is a tad experimental, because I’ve never used `allow_failures`. The idea is to get Travis testing Python 3, so we have something to work against as we add Python 3 support.

Related: #324.