### PR TITLE
Tidy up logging config and tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,4 +6,5 @@ include =
 [report]
 show_missing = True
 exclude_lines =
+    pragma: no cover
     assert False, "Should not be reachable"

--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,5 @@ include =
 
 [report]
 show_missing = True
+exclude_lines =
+    assert False, "Should not be reachable"

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -166,7 +166,7 @@ def configure_logging(config):
                 delay=True)
             handler.setFormatter(formatter)
             logger.addHandler(handler)
-        else:
+        elif config['log_to'] == 'console':
             from sys import __stderr__, __stdout__
             # STDERR
             err_handler = logging.StreamHandler(__stderr__)
@@ -179,6 +179,9 @@ def configure_logging(config):
             out_handler.addFilter(StdOutFilter())
             out_handler.setFormatter(formatter)
             logger.addHandler(out_handler)
+        else:
+            # This should be protected by ``_validate_logging_config()``.
+            assert False, "Should not be reachable"
 
         logger.handler_set = True
     return logger

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -180,7 +180,7 @@ def configure_logging(config):
             out_handler.setFormatter(formatter)
             logger.addHandler(out_handler)
 
-            logger.handler_set = True
+        logger.handler_set = True
     return logger
 
 

--- a/tests/config_t.py
+++ b/tests/config_t.py
@@ -1,6 +1,8 @@
 # -*- encoding: utf-8 -*-
 
 import logging
+from logging import StreamHandler
+from logging.handlers import RotatingFileHandler
 
 import pytest
 
@@ -72,7 +74,10 @@ class TestLoggingConfig(object):
             'log_level': 'INFO',
             'format': '%(asctime)s (%(name)s) [%(levelname)s]: %(message)s',
         }
-        configure_logging(config=config)
+        logger = configure_logging(config=config)
+
+        assert len(logger.handlers) == 2
+        assert all(isinstance(h, StreamHandler) for h in logger.handlers)
 
     def test_valid_file_config_is_okay(self):
         config = {
@@ -83,4 +88,7 @@ class TestLoggingConfig(object):
             'max_size': 100000,
             'max_backups': 5,
         }
-        configure_logging(config=config)
+        logger = configure_logging(config=config)
+
+        assert len(logger.handlers) == 1
+        assert isinstance(logger.handlers[0], RotatingFileHandler)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+# -*- encoding: utf-8 -*-
+
+import logging
+
+import pytest
+
+
+@pytest.fixture
+def reset_logger():
+    """Reset the logger at the end of a test run."""
+    yield
+    logger = logging.getLogger()
+
+    # Note: we wrap ``logger.handlers`` and ``logger.filters`` in calls to
+    # ``list()`` because they change size mid-iteration, and we want to ensure
+    # that we really do delete every handler and filter.
+    for h in list(logger.handlers):
+        logger.removeHandler(h)
+    for f in list(logger.filters):
+        logger.removeFilter(f)
+
+    try:
+        delattr(logger, 'handler_set')
+    except AttributeError:
+        pass
+
+    assert len(logger.handlers) == 0
+    assert len(logger.filters) == 0

--- a/tests/logging_t.py
+++ b/tests/logging_t.py
@@ -59,7 +59,7 @@ class TestLoggingConfig(object):
         ('debug', logging.DEBUG),
         ('slow loris', logging.DEBUG),
     ])
-    def test_log_level_is_configured_correctly(self, log_config, expected_level):
+    def test_log_level_is_configured_correctly(self, log_config, expected_level, reset_logger):
         config = {
             'log_to': 'console',
             'log_level': log_config,
@@ -68,7 +68,7 @@ class TestLoggingConfig(object):
         logger = configure_logging(config=config)
         assert logger.level == expected_level
 
-    def test_valid_console_config_is_okay(self):
+    def test_valid_console_config_is_okay(self, reset_logger):
         config = {
             'log_to': 'console',
             'log_level': 'INFO',
@@ -79,7 +79,7 @@ class TestLoggingConfig(object):
         assert len(logger.handlers) == 2
         assert all(isinstance(h, StreamHandler) for h in logger.handlers)
 
-    def test_valid_file_config_is_okay(self):
+    def test_valid_file_config_is_okay(self, reset_logger):
         config = {
             'log_to': 'file',
             'log_level': 'INFO',

--- a/tests/logging_t.py
+++ b/tests/logging_t.py
@@ -76,12 +76,14 @@ class TestLoggingConfig(object):
 
         assert len(logger.handlers) == 2
         assert all(isinstance(h, StreamHandler) for h in logger.handlers)
+        assert logger.handler_set
 
     def test_valid_file_config_is_okay(self, reset_logger):
         logger = configure_logging(config=valid_file_config)
 
         assert len(logger.handlers) == 1
         assert isinstance(logger.handlers[0], RotatingFileHandler)
+        assert logger.handler_set
 
     @pytest.mark.parametrize('config', [
         valid_console_config, valid_file_config

--- a/tests/logging_t.py
+++ b/tests/logging_t.py
@@ -82,3 +82,19 @@ class TestLoggingConfig(object):
 
         assert len(logger.handlers) == 1
         assert isinstance(logger.handlers[0], RotatingFileHandler)
+
+    @pytest.mark.parametrize('config', [
+        valid_console_config, valid_file_config
+    ])
+    def test_logging_config_is_idempotent(self, config, reset_logger):
+        """
+        If we call ``configure_logging()`` more than once, we don't get
+        extra handlers or filters created.
+        """
+        logger = configure_logging(config=config)
+        handler_count = len(logger.handlers)
+        filter_count = len(logger.filters)
+
+        configure_logging(config=config)
+        assert len(logger.handlers) == handler_count
+        assert len(logger.filters) == filter_count


### PR DESCRIPTION
I noticed that the `log_to = 'file'` arm of `configure_logging` in `webapp.py` wasn't registering as covered in the test coverage. Weird… thought I’d added a test for it?

Adding some extra assertions in `config_t.py` exposes the error – the config is preserved between different tests. It should be reset each time, so we can check Loris processes the config correctly.