### PR TITLE
Add basic flake8 linting in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ install:
  - pip install -r requirements_test.txt
 
 script:
+  - "flake8 --select=F --ignore=F841"
   - "coverage run --module py.test --verbose tests/*.py"
   - "coverage report"
 

--- a/authnServices.py
+++ b/authnServices.py
@@ -2,7 +2,6 @@ from bottle import request, response, abort, redirect
 from bottle import auth_basic, parse_auth, Bottle, run
 from bottle import debug as set_debug
 import json
-import sys
 
 try:
     from urllib import urlencode
@@ -21,7 +20,6 @@ except ImportError:
     pass
 
 import base64
-import os
 
 import jwt
 import datetime

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -300,9 +300,10 @@ class ImageInfo(object):
                         except StopIteration:
                             self.tiles.append({'width':w, 'scaleFactors':[pow(2, level)]})
 
-        self.sizes = []
-        [self.sizes.append( { 'width' : w, 'height' : h } )
-            for w,h in self.sizes_for_scales(scaleFactors)]
+        self.sizes = [
+            {'width': width, 'height': height}
+            for width, height in self.sizes_for_scales(scaleFactors)
+        ]
         self.sizes.sort(key=lambda size: max([size['width'], size['height']]))
 
     def assign_color_profile(self, jp2):

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 
 from logging import getLogger
 from os.path import join, exists, dirname, split
-from os import makedirs, rename, remove
+from os import rename, remove
 from shutil import copy
 import tempfile
 from contextlib import closing

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -384,9 +384,8 @@ class SimpleHTTPResolver(_AbstractResolver):
             if resp.status_code == 200:
                 local_rules_fp = join(cache_dir, "loris_cache." + self.auth_rules_ext)
                 if not exists(local_rules_fp):
-                    fh = open(local_rules_fp, 'w')
-                    fh.write(r.text)
-                    fh.close()
+                    with open(local_rules_fp, 'w') as fh:
+                        fh.write(resp.text)
         except:
             # No connection available
             pass

--- a/loris/transforms.py
+++ b/loris/transforms.py
@@ -7,12 +7,10 @@ import multiprocessing
 from logging import getLogger
 from math import ceil, log
 from os import path, unlink, devnull
-import cStringIO
 import platform
 import random
 import string
 import subprocess
-import sys
 
 try:
     from cStringIO import BytesIO

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -29,7 +29,7 @@ from werkzeug.wrappers import (
 )
 
 from loris import constants, img, transforms
-from loris.img_info import ImageInfo, InfoCache
+from loris.img_info import InfoCache
 from loris.loris_exception import (
     ConfigError,
     ImageException,

--- a/misc/jp2_kakadu_pillow.py
+++ b/misc/jp2_kakadu_pillow.py
@@ -3,7 +3,6 @@
 
 from PIL import Image
 from PIL.ImageFile import Parser
-from os import makedirs, path, unlink
 import subprocess
 import sys
 

--- a/misc/openjpeg_transform.py
+++ b/misc/openjpeg_transform.py
@@ -5,7 +5,6 @@ import timeit
 import subprocess
 from PIL import Image
 from PIL.ImageFile import Parser
-import subprocess
 import sys
 
 def mk_tile_with_PIL():

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,3 +4,4 @@ hypothesis >= 3.11.6
 pytest-cov==2.5.1
 pytest==3.1.3
 responses == 0.3.0
+flake8

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from grp import getgrnam
 from pwd import getpwnam
 from setuptools import setup
 from setuptools.command.install import install
-from sys import stderr, stdout, exit, version_info
+from sys import stderr, stdout, exit
 import loris
 import os
 import shutil

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -461,6 +461,6 @@ def suite():
     test_suites = []
     test_suites.append(unittest.makeSuite(InfoUnit, 'test'))
     test_suites.append(unittest.makeSuite(InfoFunctional, 'test'))
-    test_suites.append(unittest.makeSuite(InfoCache, 'test'))
+    test_suites.append(unittest.makeSuite(TestInfoCache, 'test'))
     test_suite = unittest.TestSuite(test_suites)
     return test_suite

--- a/tests/img_t.py
+++ b/tests/img_t.py
@@ -4,9 +4,7 @@ from __future__ import absolute_import
 
 from os.path import exists
 from os.path import islink
-from os.path import isfile
 from os.path import join
-import unittest
 
 import mock
 import pytest

--- a/tests/parameters_t.py
+++ b/tests/parameters_t.py
@@ -12,7 +12,7 @@ import pytest
 from loris import img_info
 from loris.loris_exception import RequestException, SyntaxException
 from loris.parameters import (
-    DECIMAL_ONE, FULL_MODE, PCT_MODE, PIXEL_MODE,
+    FULL_MODE, PCT_MODE, PIXEL_MODE,
     RegionParameter, RotationParameter, SizeParameter,
 )
 from tests import loris_t

--- a/tests/webapp_t.py
+++ b/tests/webapp_t.py
@@ -15,7 +15,7 @@ from werkzeug.http import http_date
 from werkzeug.test import EnvironBuilder
 from werkzeug.wrappers import Request
 
-from loris import img_info, loris_exception, webapp
+from loris import img_info, webapp
 from loris.loris_exception import ConfigError
 from loris.transforms import KakaduJP2Transformer, OPJ_JP2Transformer
 from tests import loris_t


### PR DESCRIPTION
The idea is to catch particularly egregious errors, e.g. undefined variables, before they get into the main branch.