### PR TITLE
Improve the test coverage of authorizer.py

### DIFF
--- a/loris/authorizer.py
+++ b/loris/authorizer.py
@@ -187,9 +187,6 @@ class RulesAuthorizer(_AbstractAuthorizer):
         self.token_secret = config['token_secret']
 
         self.use_jwt = config.get('use_jwt', True)
-        if not self.use_jwt:
-            if not 'salt' in config:
-                raise AuthorizerException("Rules Authorizer needs salt config")
         self.salt = config.get('salt', '')
         self.roles_key = config.get('roles_key', 'roles')
         self.id_key = config.get('id_key', 'sub')
@@ -202,6 +199,12 @@ class RulesAuthorizer(_AbstractAuthorizer):
             raise ConfigError(
                 'Missing mandatory parameters for %s: %s' %
                 (type(self).__name__, ','.join(missing_keys))
+            )
+
+        if not config.get('use_jwt', True) and ('salt' not in config):
+            raise ConfigError(
+                'If use_jwt=%r, you must supply the "salt" config parameter' %
+                config['use_jwt']
             )
 
     def kdf(self):

--- a/loris/authorizer.py
+++ b/loris/authorizer.py
@@ -279,8 +279,6 @@ class RulesAuthorizer(_AbstractAuthorizer):
                 value = jwt.decode(cval, secret, verify=False)                
                 logger.debug(value)
                 raise AuthorizerException(message="invalidCredentials: expired")
-            except:
-                raise
         else:
             cval = cval.encode('utf-8')
             key = base64.urlsafe_b64encode(self.kdf().derive(secret.encode('utf-8')))

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -115,10 +115,7 @@ def _validate_logging_config(config):
     Validate the logging config before setting up a logger.
     """
     mandatory_keys = ['log_to', 'log_level', 'format']
-    missing_keys = []
-    for key in mandatory_keys:
-        if key not in config:
-            missing_keys.append(key)
+    missing_keys = [key for key in mandatory_keys if key not in config]
 
     if missing_keys:
         raise ConfigError(

--- a/tests/authorizer_t.py
+++ b/tests/authorizer_t.py
@@ -1,6 +1,7 @@
 
 from loris.authorizer import _AbstractAuthorizer, NullAuthorizer,\
     NooneAuthorizer, SingleDegradingAuthorizer, RulesAuthorizer
+from loris.loris_exception import ConfigError
 from loris.img_info import ImageInfo
 
 import unittest
@@ -283,3 +284,29 @@ class Test_RulesAuthorizer(unittest.TestCase):
             }}
         svcs = self.authorizer.get_services_info(self.badInfo)
         self.assertEqual(svcs['service']['profile'], "http://iiif.io/api/auth/1/login")
+
+    def test_missing_cookie_secret_is_configerror(self):
+        config = {
+            'cookie_service': 'cookie.example.com',
+            'token_service': 'token.example.com',
+            'token_secret': 't0k3ns3kr1t'
+        }
+        with pytest.raises(ConfigError) as err:
+            RulesAuthorizer(config)
+        assert (
+            'Missing mandatory parameters for RulesAuthorizer: cookie_secret' ==
+            err.value.message
+        )
+
+    def test_missing_token_secret_is_configerror(self):
+        config = {
+            'cookie_service': 'cookie.example.com',
+            'token_service': 'token.example.com',
+            'cookie_secret': 'c00ki3sekr1t',
+        }
+        with pytest.raises(ConfigError) as err:
+            RulesAuthorizer(config)
+        assert (
+            'Missing mandatory parameters for RulesAuthorizer: token_secret' ==
+            err.value.message
+        )

--- a/tests/authorizer_t.py
+++ b/tests/authorizer_t.py
@@ -310,3 +310,18 @@ class Test_RulesAuthorizer(unittest.TestCase):
             'Missing mandatory parameters for RulesAuthorizer: token_secret' ==
             err.value.message
         )
+
+    def test_false_use_jwt_without_salt_is_configerror(self):
+        config = {
+            'cookie_service': 'cookie.example.com',
+            'token_service': 'token.example.com',
+            'cookie_secret': 'c00ki3sekr1t',
+            'token_secret': 't0k3ns3kr1t',
+            'use_jwt': False,
+        }
+        with pytest.raises(ConfigError) as err:
+            RulesAuthorizer(config)
+        assert (
+            'If use_jwt=False, you must supply the "salt" config parameter' ==
+            err.value.message
+        )


### PR DESCRIPTION
Specifically, adding tests to cover the cases where the user tries to pass invalid config.

I’ve consolidated all the config validation code, and also switched it to use `ConfigError`, which is consistent with other parts of Loris when invalid config is detected.