### PR TITLE
Add a `safe_rename` function that's atomic and filesystem-aware

### DIFF
--- a/etc/loris2.conf
+++ b/etc/loris2.conf
@@ -97,13 +97,9 @@ src_img_root = '/usr/local/share/images' # r--
 # url = 'http://<server>/fedora/objects/%s/datastreams/%s/content' # as used with delimiter option below
 
 [img.ImageCache]
-# must be on the same volume as tmp_dp, for atomic move operations
-# will crash if on another volume
 cache_dp = '/var/cache/loris' # rwx
 
 [img_info.InfoCache]
-# must be on the same volume as tmp_dp, for atomic move operations
-# will crash if on another volume
 cache_dp = '/var/cache/loris' # rwx
 
 [transforms]

--- a/loris/img.py
+++ b/loris/img.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 from datetime import datetime
 import errno
 from logging import getLogger
-from os import path, rename
+from os import path
 
 try:
     from urllib.parse import quote_plus, unquote
@@ -15,7 +15,7 @@ except ImportError:  # Python 2
 
 from loris.loris_exception import ImageException
 from loris.parameters import RegionParameter, RotationParameter, SizeParameter
-from loris.utils import mkdir_p, symlink
+from loris.utils import mkdir_p, safe_rename, symlink
 
 logger = getLogger(__name__)
 
@@ -274,5 +274,5 @@ class ImageCache(dict):
 
     def upsert(self, image_request, temp_fp):
         target_fp = self.create_dir_and_return_file_path(image_request)
-        rename(temp_fp, target_fp)
+        safe_rename(temp_fp, target_fp)
         return target_fp

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import
 
 from logging import getLogger
 from os.path import join, exists, dirname, split
-from os import rename, remove
+from os import remove
 from shutil import copy
 import tempfile
 from contextlib import closing
@@ -26,7 +26,7 @@ import requests
 
 from loris import constants
 from loris.loris_exception import ResolverException
-from loris.utils import mkdir_p
+from loris.utils import mkdir_p, safe_rename
 from loris.img_info import ImageInfo
 
 
@@ -368,7 +368,7 @@ class SimpleHTTPResolver(_AbstractResolver):
                 logger.info('another process downloaded src image %s', local_fp)
                 remove(tmp_file.name)
             else:
-                rename(tmp_file.name, local_fp)
+                safe_rename(tmp_file.name, local_fp)
                 logger.info("Copied %s to %s", source_url, local_fp)
 
         # Check for rules file associated with image file

--- a/loris/utils.py
+++ b/loris/utils.py
@@ -46,17 +46,6 @@ def symlink(src, dst, force=True):
     os.symlink(src, dst)
 
 
-def remove_f(path):
-    """Remove a file at ``path``, but don't error if it doesn't exist."""
-    try:
-        os.remove(path)
-    except OSError as err:
-        if err.errno == errno.ENOENT:
-            pass
-        else:
-            raise
-
-
 def safe_rename(src, dst):
     """Rename a file from ``src`` to ``dst``.
 

--- a/loris/utils.py
+++ b/loris/utils.py
@@ -3,9 +3,11 @@
 from __future__ import absolute_import
 
 import errno
+import glob
 import logging
 import os
 import shutil
+import uuid
 
 
 logger = logging.getLogger(__name__)
@@ -44,6 +46,17 @@ def symlink(src, dst, force=True):
     os.symlink(src, dst)
 
 
+def remove_f(path):
+    """Remove a file at ``path``, but don't error if it doesn't exist."""
+    try:
+        os.remove(path)
+    except OSError as err:
+        if err.errno == errno.ENOENT:
+            pass
+        else:
+            raise
+
+
 def safe_rename(src, dst):
     """Rename a file from ``src`` to ``dst``.
 
@@ -52,6 +65,11 @@ def safe_rename(src, dst):
 
     *   Moves must be atomic.  Otherwise Loris may serve a partial image from
         a cache, which causes an error.  ``shutil.move()`` is not atomic.
+
+        Note that multiple threads may try to write to the cache at once,
+        so atomicity is required to ensure the serving on one thread doesn't
+        pick up a partially saved image from another thread.
+
     *   Moves must work across filesystems.  Often temp directories and the
         cache directories live on different filesystems.  ``os.rename()`` can
         throw errors if run across filesystems.
@@ -59,14 +77,60 @@ def safe_rename(src, dst):
     So we try ``os.rename()``, but if we detect a cross-filesystem copy, we
     switch to ``shutil.move()`` with some wrappers to make it atomic.
     """
+    logger.debug('Renaming %r to %r', src, dst)
     try:
         os.rename(src, dst)
     except OSError as err:
+        logger.debug('Calling os.rename(%r, %r) failed with %r', src, dst, err)
         if err.errno == errno.EXDEV:
-            # First we move it across the filesystem to a temporary file
-            # in a non-atomic way, then move it to the final location
-            # atomically.
-            shutil.move(src, dst + '.tmp')
-            os.rename(dst + '.tmp', dst)
+
+            # This is based on the safe, atomic file copying algorithm
+            # described in https://stackoverflow.com/a/28090883/1558022.
+            #
+            # We're assuming that ``src`` is a temporary file in a unique
+            # location.  Multiple threads may try to write the same file
+            # to ``dst``, but we're the only thread that may be interacting
+            # with ``src``.  So we don't need to worry about it disappearing
+            # under our feet.
+
+            # First, generate a unique ID, and copy `<src>` to the target
+            # directory with a temporary name `<dst>.<ID>.tmp`.  Because we're
+            # copying across a filesystem boundary, this may not be atomic.
+            mole_id = uuid.uuid4()
+            tmp_dst = shutil.copyfile(src, '%s.%s.tmp' % (dst, mole_id))
+
+            # Now we rename the copy (atomically) to `<dst>.<ID>.mole.tmp`.
+            # Files within the same directory should be on the same filesystem.
+            mole_dst = '%s.%s.mole.tmp' % (dst, mole_id)
+            os.rename(tmp_dst, mole_dst)
+
+            # At this point, any files name `<dst>.<ID>.mole.tmp` are complete
+            # copies of the source file.  Pick the lowest mole.  If that's
+            # not the one we just created, delete ours.
+            matching = sorted(glob.glob('dst.*.mole.tmp'))
+            if mole_dst != matching[0]:
+                remove_f(mole_dst)
+
+            mole_dst = matching[0]
+
+            # If ``dst`` exists, another process has beaten us.  Clean up
+            # our mole and the source file.
+            if os.path.exists(dst):
+                remove_f(mole_dst)
+                os.unlink(src)
+                return
+
+            # Otherwise, rename the temporary file to its final name.  Don't
+            # worry if it's already gone -- it just means another process
+            # did it first.
+            try:
+                os.rename(mole_dst, dst)
+            except OSError as err:
+                if err.errno == errno.ENOENT:
+                    pass
+                else:
+                    raise
+
+            os.unlink(src)
         else:
             raise

--- a/loris/utils.py
+++ b/loris/utils.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import
 
 import errno
-import glob
 import logging
 import os
 import shutil

--- a/loris/utils.py
+++ b/loris/utils.py
@@ -44,7 +44,7 @@ def symlink(src, dst, force=True):
     os.symlink(src, dst)
 
 
-def rename(src, dst):
+def safe_rename(src, dst):
     """Rename a file from ``src`` to ``dst``.
 
     We use a custom version rather than the standard library because we

--- a/loris/utils.py
+++ b/loris/utils.py
@@ -41,3 +41,21 @@ def symlink(src, dst, force=True):
         os.unlink(dst)
 
     os.symlink(src, dst)
+
+
+def rename(src, dst):
+    """Rename a file from ``src`` to ``dst``.
+
+    We use a custom version rather than the standard library because we
+    have two requirements:
+
+    *   Moves must be atomic.  Otherwise Loris may serve a partial image from
+        a cache, which causes an error.  ``shutil.move()`` is not atomic.
+    *   Moves must work across filesystems.  Often temp directories and the
+        cache directories live on different filesystems.  ``os.rename()`` can
+        throw errors if run across filesystems.
+
+    So we try ``os.rename()``, but if we detect a cross-filesystem copy, we
+    switch to ``shutil.move()`` with some wrappers to make it atomic.
+    """
+    os.rename(src, dst)

--- a/tests/utils_t.py
+++ b/tests/utils_t.py
@@ -69,32 +69,6 @@ class TestSafeRename:
         assert os.path.exists(dst)
         assert open(dst, 'rb').read() == b'hello world'
 
-    def test_renames_file_across_filesystems_correctly(self, src, dst):
-        # For any given test setup, we can't guarantee where filesystem
-        # boundaries lie, so we patch ``os.rename`` to throw an error that
-        # looks like it's copying across a filesystem.
-        message = "Exception thrown in utils_t.py for TestRename"
-
-        copy_of_rename = os.rename
-
-        def side_effect(s, d):
-            """This raises an errno.EXDEV if it detects a rename between
-            the ``src`` and ``dst`` used in the test, but otherwise proceeds
-            as normal.
-            """
-            if s == src and d == dst:
-                raise OSError(errno.EXDEV, message)
-            else:
-                copy_of_rename(s, d)
-
-        m = mock.Mock(side_effect=side_effect)
-        with mock.patch('loris.utils.os.rename', m):
-            utils.safe_rename(src, dst)
-
-        assert not os.path.exists(src)
-        assert os.path.exists(dst)
-        assert open(dst, 'rb').read() == b'hello world'
-
     def test_if_error_is_unexpected_then_is_raised(self, src, dst):
         """
         If the error from ``os.rename()`` isn't because we're trying to copy

--- a/tests/utils_t.py
+++ b/tests/utils_t.py
@@ -2,7 +2,6 @@
 
 import errno
 import os
-import shutil
 
 import mock
 import pytest

--- a/tests/utils_t.py
+++ b/tests/utils_t.py
@@ -92,6 +92,7 @@ class TestSafeRename:
         with mock.patch('loris.utils.os.rename', m):
             utils.safe_rename(src, dst)
 
+        assert not os.path.exists(src)
         assert os.path.exists(dst)
         assert open(dst, 'rb').read() == b'hello world'
 

--- a/tests/utils_t.py
+++ b/tests/utils_t.py
@@ -52,6 +52,13 @@ def dst(tmpdir):
 
 
 class TestSafeRename:
+    """Tests for ``utils.safe_rename()``.
+
+    Note: one key characteristic of ``safe_rename()`` is that copies are
+    atomic.  That's not tested here, because I couldn't think of a way to
+    easily test that file moves are atomic in Python.
+
+    """
 
     def test_renames_file_correctly(self, src, dst):
         assert os.path.exists(src)

--- a/tests/utils_t.py
+++ b/tests/utils_t.py
@@ -1,6 +1,5 @@
 # -*- encoding: utf-8
 
-import errno
 import os
 
 import mock

--- a/tests/utils_t.py
+++ b/tests/utils_t.py
@@ -51,13 +51,13 @@ def dst(tmpdir):
     return str(tmpdir.join('dst.txt'))
 
 
-class TestRename:
+class TestSafeRename:
 
     def test_renames_file_correctly(self, src, dst):
         assert os.path.exists(src)
         assert not os.path.exists(dst)
 
-        utils.rename(src, dst)
+        utils.safe_rename(src, dst)
 
         assert not os.path.exists(src)
         assert os.path.exists(dst)
@@ -83,7 +83,7 @@ class TestRename:
 
         m = mock.Mock(side_effect=side_effect)
         with mock.patch('loris.utils.os.rename', m):
-            utils.rename(src, dst)
+            utils.safe_rename(src, dst)
 
         assert os.path.exists(dst)
         assert open(dst, 'rb').read() == b'hello world'
@@ -97,7 +97,7 @@ class TestRename:
         m = mock.Mock(side_effect=OSError(-1, message))
         with mock.patch('loris.utils.os.rename', m):
             with pytest.raises(OSError):
-                utils.rename(src, dst)
+                utils.safe_rename(src, dst)
 
 
 @pytest.fixture


### PR DESCRIPTION
This uses the proposed approach in #379 – first try to copy the file using `os.rename()`, but if we detect we’re trying to copy across a filesystem boundary and the OS gets upset, we fall back to using `shutil.move()` in a way that’s atomic.

Resolves #379.

/cc @giorgiosironi @bcail 