### PR TITLE
Allow asterisks in identifiers

### DIFF
--- a/loris/constants.py
+++ b/loris/constants.py
@@ -37,7 +37,7 @@ EXTENSION_MAP = {
         'tiff': 'tif',
     }
 
-_IDENT = r'(?P<ident>[\w:\-\.\%\/]+)'
+_IDENT = r'(?P<ident>[\w:\-\*\.\%\/]+)'
 _REGION = r'(?P<region>[\w:\.\,]+)'
 _SIZE = r'(?P<size>\!?[\w:\.\,]+)'
 _ROTATION = r'(?P<rotation>\!?\d+\.?\d*)'

--- a/tests/constants_t.py
+++ b/tests/constants_t.py
@@ -1,20 +1,23 @@
 #-*- coding: utf-8 -*-
 
-import unittest
+import pytest
 
 from loris import constants
 
-class TestImageRequest(unittest.TestCase):
+class TestImageRequest(object):
 
     def test_valid_filenames(self):
         self._assert_valid('/123.jpg/full/full/0/default.jpg')
 
-    def test_valid_special_characters(self):
-        self._assert_valid('/a*b/full/full/0/default.jpg')
-        self._assert_valid('/a:b/full/full/0/default.jpg')
-        self._assert_valid('/a-b/full/full/0/default.jpg')
-        self._assert_valid('/a%b/full/full/0/default.jpg')
+    @pytest.mark.parametrize('path', [
+        '/a*b/full/full/0/default.jpg',
+        '/a:b/full/full/0/default.jpg',
+        '/a-b/full/full/0/default.jpg',
+        '/a%b/full/full/0/default.jpg'
+    ])
+    def test_valid_special_characters(self, path):
+        self._assert_valid(path)
 
     def _assert_valid(self, path):
-        self.assertIsNotNone(constants.IMAGE_RE.match(path))
+        assert constants.IMAGE_RE.match(path) is not None
 

--- a/tests/constants_t.py
+++ b/tests/constants_t.py
@@ -1,0 +1,20 @@
+#-*- coding: utf-8 -*-
+
+import unittest
+
+from loris import constants
+
+class TestImageRequest(unittest.TestCase):
+
+    def test_valid_filenames(self):
+        self._assert_valid('/123.jpg/full/full/0/default.jpg')
+
+    def test_valid_special_characters(self):
+        self._assert_valid('/a*b/full/full/0/default.jpg')
+        self._assert_valid('/a:b/full/full/0/default.jpg')
+        self._assert_valid('/a-b/full/full/0/default.jpg')
+        self._assert_valid('/a%b/full/full/0/default.jpg')
+
+    def _assert_valid(self, path):
+        self.assertIsNotNone(constants.IMAGE_RE.match(path))
+


### PR DESCRIPTION
One of our image sources is Medium. We found out some of their image filenames contains `*` characters, which is weird when used from a shell but valid.

Originally hot-fixed on our version with https://github.com/elifesciences/loris/commit/06ecff044accc8d6ac5f8d945515acc48450aebe and been in production for several months.