### PR TITLE
Ensure that is_resolvable() only returns a boolean

### DIFF
--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -528,21 +528,6 @@ class TemplateHTTPResolver(SimpleHTTPResolver):
             options['verify'] = conf['ssl_check']
         return (url, options)
 
-    def is_resolvable(self, ident):
-        # We can raise a ``ResolverException`` in ``_web_request_url()`` if
-        # somebody tries to look up a URL that doesn't match any of the
-        # templates.  In turn, this causes ``is_resolvable()`` to rethrow
-        # that exception and return a 500 to the user.
-        #
-        # In this case, we should catch the exception and return a boolean.
-        try:
-            return super(TemplateHTTPResolver, self).is_resolvable(ident)
-        except ResolverException as exc:
-            if exc.http_status == 404:
-                return False
-            else:
-                raise
-
 
 class SourceImageCachingResolver(_AbstractResolver):
     '''

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -257,12 +257,10 @@ class SimpleHTTPResolver(_AbstractResolver):
             try:
                 if self.head_resolvable:
                     response = requests.head(url, **options)
-                    if response.ok:
-                        return True
+                    return response.ok
                 else:
                     with closing(requests.get(url, stream=True, **options)) as response:
-                        if response.ok:
-                            return True
+                        return response.ok
             except requests.ConnectionError:
                 return False
 
@@ -277,11 +275,11 @@ class SimpleHTTPResolver(_AbstractResolver):
             return self.format_from_ident(ident)
 
     def _web_request_url(self, ident):
-        if (ident.startswith('http://') or ident.startswith('https://')) and self.uri_resolvable:
+        if ident.startswith(('http://', 'https://')) and self.uri_resolvable:
             url = ident
         else:
             url = self.source_prefix + ident + self.source_suffix
-        if not (url.startswith('http://') or url.startswith('https://')):
+        if not url.startswith(('http://', 'https://')):
             logger.warn('Bad URL request at %s for identifier: %s.', url, ident)
             public_message = 'Bad URL request made for identifier: %s.' % (ident,)
             raise ResolverException(404, public_message)

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -246,7 +246,13 @@ class SimpleHTTPResolver(_AbstractResolver):
         if exists(fp):
             return True
         else:
-            (url, options) = self._web_request_url(ident)
+            try:
+                (url, options) = self._web_request_url(ident)
+            except ResolverException as exc:
+                if exc.http_status == 404:
+                    return False
+                else:
+                    raise
 
             try:
                 if self.head_resolvable:

--- a/tests/resolver_t.py
+++ b/tests/resolver_t.py
@@ -380,6 +380,17 @@ class TestSimpleHTTPResolver(object):
         resolver = SimpleHTTPResolver(config=config)
         assert resolver.is_resolvable(ident=ident) == expected_resolvable
 
+    @pytest.mark.parametrize('head_resolvable', [True, False])
+    def test_non_http_rejected_as_not_resolvable(self, head_resolvable):
+        config = {
+            'cache_root': '/var/cache/loris',
+            'source_prefix': 'irc://example.irc/loris/',
+            'uri_resolvable': True,
+            'head_resolvable': head_resolvable,
+        }
+        resolver = SimpleHTTPResolver(config=config)
+        assert not resolver.is_resolvable(ident='example.png')
+
 
 class Test_TemplateHTTPResolver(object):
 


### PR DESCRIPTION
We're running Loris with a TemplateHTTPResolver, and we've seen a trickle of 500 errors with the following traceback, caused when a user requests a URL that doesn't match any of our templates:

```
2017-11-17 16:08:21,235 (loris.resolver) [WARNING]: Bad URL request for identifier: 'full/full/0/default.jpg'.
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/Loris-2.0.0-py2.7.egg/loris/webapp.py", line 445, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python2.7/dist-packages/Loris-2.0.0-py2.7.egg/loris/webapp.py", line 388, in wsgi_app
    response = self.route(request)
  File "/usr/local/lib/python2.7/dist-packages/Loris-2.0.0-py2.7.egg/loris/webapp.py", line 408, in route
    if not self.resolver.is_resolvable(ident):
  File "/usr/local/lib/python2.7/dist-packages/Loris-2.0.0-py2.7.egg/loris/resolver.py", line 248, in is_resolvable
    (url, options) = self._web_request_url(ident)
  File "/usr/local/lib/python2.7/dist-packages/Loris-2.0.0-py2.7.egg/loris/resolver.py", line 486, in _web_request_url
    raise ResolverException(404, public_message)
loris.loris_exception.ResolverException: Bad URL request made for identifier: 'full/full/0/default.jpg'.
```

Digging into the error, I found a couple of places where `is_resolvable()` could throw an exception, rather than return a boolean. Because the caller in `webapp.py` expects it to return a boolean, there's no error-handling logic and the exception gets raised as a 500 (despite having a 404 HTTP status).

This patch fixes two sources of those errors, and adds a bunch of tests around this function.

Ready for review.