### PR TITLE
Refactor the Exception classes to drop the notion of "http_status"

### DIFF
--- a/loris/img.py
+++ b/loris/img.py
@@ -187,7 +187,7 @@ class ImageRequest(object):
     def info(self):
         if self._info is None:
             # For dev purposes only. This should never happen.
-            raise ImageException(http_status=500, message='Image.info not set!')
+            raise ImageException('Image.info not set!')
         else:
             return self._info
 

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -158,7 +158,7 @@ class ImageInfo(object):
         else:
             raise ImageInfoException(
                 "Didn't get a source format, or at least one we recognize (%r)." %
-                src_format
+                self.src_format
             )
         # in case of ii = ImageInfo().from_image_file()
         return self

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -88,8 +88,9 @@ class ImageInfo(object):
             except AttributeError:
                 bad_attrs.append(k)
         if bad_attrs:
-            message = "Invalid parameters in extraInfo: %s" % ', '.join(bad_attrs)
-            raise ImageInfoException(message)
+            raise ImageInfoException(
+                "Invalid parameters in extraInfo: %s." % ', '.join(bad_attrs)
+            )
 
         # If constructed from JSON, the pixel info will already be processed
         if app:
@@ -97,7 +98,7 @@ class ImageInfo(object):
                 formats = app.transformers[src_format].target_formats
             except KeyError:
                 raise ImageInfoException(
-                    'Didn\'t get a source format, or at least one we recognize ("%s")' %
+                    "Didn't get a source format, or at least one we recognize (%r)." %
                     src_format
                 )
             # Finish setting up the info from the image file
@@ -156,7 +157,8 @@ class ImageInfo(object):
             self._extract_with_pillow(self.src_img_fp)
         else:
             raise ImageInfoException(
-                'Didn\'t get a source format, or at least one we recognize ("%s")' % self.src_format
+                "Didn't get a source format, or at least one we recognize (%r)." %
+                src_format
             )
         # in case of ii = ImageInfo().from_image_file()
         return self

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -89,15 +89,17 @@ class ImageInfo(object):
                 bad_attrs.append(k)
         if bad_attrs:
             message = "Invalid parameters in extraInfo: %s" % ', '.join(bad_attrs)
-            raise ImageInfoException(http_status=500, message=message)
+            raise ImageInfoException(message)
 
         # If constructed from JSON, the pixel info will already be processed
         if app:
             try:
                 formats = app.transformers[src_format].target_formats
             except KeyError:
-                m = 'Didn\'t get a source format, or at least one we recognize ("%s")' % src_format
-                raise ImageInfoException(500, m)
+                raise ImageInfoException(
+                    'Didn\'t get a source format, or at least one we recognize ("%s")' %
+                    src_format
+                )
             # Finish setting up the info from the image file
             self.from_image_file(formats, app.max_size_above_full)
 
@@ -124,7 +126,7 @@ class ImageInfo(object):
         new_inst.sizes = j.get(u'sizes')
         new_inst.profile = j.get(u'profile')
         new_inst.service = j.get('service', {})
-        
+
         # Also add src_img_fp if available
         new_inst.src_img_fp = j.get('_src_img_fp', '')
         new_inst.src_format = j.get('_src_format', '')
@@ -153,8 +155,9 @@ class ImageInfo(object):
         elif self.src_format  in ('jpg','tif','png'):
             self._extract_with_pillow(self.src_img_fp)
         else:
-            m = 'Didn\'t get a source format, or at least one we recognize ("%s")' % self.src_format
-            raise ImageInfoException(http_status=500, message=m)
+            raise ImageInfoException(
+                'Didn\'t get a source format, or at least one we recognize ("%s")' % self.src_format
+            )
         # in case of ii = ImageInfo().from_image_file()
         return self
 
@@ -182,7 +185,7 @@ class ImageInfo(object):
             if (not initial_bytes[:12] == '\x00\x00\x00\x0cjP  \r\n\x87\n') or \
                 (not initial_bytes[16:] == 'ftypjp2 '):
                 logger.warning('Invalid JP2 file at %s', fp)
-                raise ImageInfoException(http_status=500, message='Invalid JP2 file')
+                raise ImageInfoException('Invalid JP2 file')
 
             #grab width and height
             window = deque([], 4)

--- a/loris/loris_exception.py
+++ b/loris/loris_exception.py
@@ -1,37 +1,56 @@
-from __future__ import absolute_import
-
+# -*- encoding: utf-8 -*-
 
 class LorisException(Exception):
-    """Base exception class for Loris.
+    """Base exception class for all errors raised by Loris."""
+    pass
 
-    See <http://www-sul.stanford.edu/iiif/image-api/#error>
 
-    Attributes:
-        http_status (int): the HTTP status the should be sent with the response.
-        supplied_value (str): the parameter that caused the problem.
-        msg (str): any additional info about what went wrong.
+class HTTPException(Exception):
+    """Base class for exceptions that are returned as an HTTP response
+    to the user.
+
+    See http://iiif.io/api/image/2.1/#error-conditions.
+
+    :param http_status: The HTTP status that should be sent with the
+        associated HTTP response.
+    :type http_status: int
+    :param message: Information about the error.
+    :type msg: str
+
     """
-    def __init__(self, http_status=400, message=''):
-        """
-        Kwargs:
-            http_status (int): the HTTP status the should be sent with the
-                response.
-            msg (str): any additional info about what went wrong.
-            supplied_value (str): the parameter that caused the problem.
-        """
-        # message = '%s: %s (%d)' % (self.__class__.__name__, message, http_status)
-        super(LorisException, self).__init__(message)
+    def __init__(self, http_status, message):
+        super(HTTPException, self).__init__(message)
         self.http_status = http_status
 
-class SyntaxException(LorisException): pass
-class RequestException(LorisException): pass
-class ImageException(LorisException): pass
-class ImageInfoException(LorisException): pass
-class ResolverException(LorisException): pass
-class TransformException(LorisException): pass
-class AuthorizerException(LorisException): pass
+
+class SyntaxException(LorisException, HTTPException):
+    pass
+
+
+class RequestException(LorisException, HTTPException):
+    pass
+
+
+class ImageException(LorisException, HTTPException):
+    pass
+
+
+class ImageInfoException(LorisException, HTTPException):
+    pass
+
+
+class ResolverException(LorisException, HTTPException):
+    pass
+
+
+class TransformException(LorisException, HTTPException):
+    pass
+
+
+class AuthorizerException(LorisException, HTTPException):
+    pass
+
 
 class ConfigError(LorisException):
     """Raised for errors in the user config."""
-    def __init__(self, message):
-        super(ConfigError, self).__init__(http_status=None, message=message)
+    pass

--- a/loris/loris_exception.py
+++ b/loris/loris_exception.py
@@ -5,49 +5,31 @@ class LorisException(Exception):
     pass
 
 
-class HTTPException(Exception):
-    """Base class for exceptions that are returned as an HTTP response
-    to the user.
-
-    See http://iiif.io/api/image/2.1/#error-conditions.
-
-    :param http_status: The HTTP status that should be sent with the
-        associated HTTP response.
-    :type http_status: int
-    :param message: Information about the error.
-    :type msg: str
-
-    """
-    def __init__(self, http_status, message):
-        super(HTTPException, self).__init__(message)
-        self.http_status = http_status
-
-
-class SyntaxException(LorisException, HTTPException):
+class SyntaxException(LorisException):
     pass
 
 
-class RequestException(LorisException, HTTPException):
+class RequestException(LorisException):
     pass
 
 
-class ImageException(LorisException, HTTPException):
+class ImageException(LorisException):
     pass
 
 
-class ImageInfoException(LorisException, HTTPException):
+class ImageInfoException(LorisException):
     pass
 
 
-class ResolverException(LorisException, HTTPException):
+class ResolverException(LorisException):
     pass
 
 
-class TransformException(LorisException, HTTPException):
+class TransformException(LorisException):
     pass
 
 
-class AuthorizerException(LorisException, HTTPException):
+class AuthorizerException(LorisException):
     pass
 
 

--- a/loris/parameters.py
+++ b/loris/parameters.py
@@ -117,16 +117,20 @@ class RegionParameter(object):
 
     def _check_for_oob_errors(self):
         if any(axis < 0 for axis in (self.pixel_x, self.pixel_y)):
-            msg = 'x and y region parameters must be 0 or greater (%s)' % (self.uri_value,)
-            raise RequestException(msg)
+            raise RequestException(
+                "x and y region parameters must be 0 or greater (%s)." %
+                self.uri_value
+            )
         if self.decimal_x >= DECIMAL_ONE:
-            msg = 'Region x parameter is greater than the width of the image.\n'
-            msg +='Image width is %d' % (self.img_info.width,)
-            raise RequestException(msg)
+            raise RequestException(
+                "Region x parameter is greater than the width of the image. "
+                "Image width is %d" % self.img_info.width
+            )
         if self.decimal_y >= DECIMAL_ONE:
-            msg = 'Region y parameter is greater than the height of the image.\n'
-            msg +='Image height is %d' % (self.img_info.height,)
-            raise RequestException(msg)
+            raise RequestException(
+                "Region y parameter is greater than the height of the image. "
+                "Image height is %d" % self.img_info.height
+            )
 
     def _populate_slots_for_full(self):
         self.canonical_uri_value = FULL_MODE
@@ -149,14 +153,15 @@ class RegionParameter(object):
         dimensions = map(float, self.uri_value.split(':')[1].split(','))
 
         if len(dimensions) != 4:
-            msg = 'Exactly (4) coordinates must be supplied'
-            raise SyntaxException(msg)
+            raise SyntaxException("Exactly (4) coordinates must be supplied.")
         if any(n > 100.0 for n in dimensions):
-            msg = 'Region percentages must be less than or equal to 100.'
-            raise RequestException(msg)
+            raise RequestException(
+                "Region percentages must be less than or equal to 100."
+            )
         if any((n <= 0) for n in dimensions[2:]):
-            msg = 'Width and Height Percentages must be greater than 0.'
-            raise RequestException(msg)
+            raise RequestException(
+                "Width and Height Percentages must be greater than 0."
+            )
 
         # decimals
         self.decimal_x, self.decimal_y, self.decimal_w, \
@@ -185,11 +190,9 @@ class RegionParameter(object):
     def _pixel_dims_to_ints(self):
         dimensions = map(int, self.uri_value.split(','))
         if any(n <= 0 for n in dimensions[2:]):
-            msg = 'Width and height must be greater than 0'
-            raise RequestException(msg)
+            raise RequestException("Width and height must be greater than 0.")
         if len(dimensions) != 4:
-            msg = 'Exactly (4) coordinates must be supplied'
-            raise SyntaxException(msg)
+            raise SyntaxException("Exactly (4) coordinates must be supplied.")
         return dimensions
 
     def _populate_slots_from_pixels(self, dimensions):
@@ -232,8 +235,9 @@ class RegionParameter(object):
             elif region_segment.split(':')[0] == 'pct':
                 return PCT_MODE
             else:
-                msg = 'Region syntax "%s" is not valid' % (region_segment,)
-                raise SyntaxException(msg)
+                raise SyntaxException(
+                    "Region syntax %r is not valid." % region_segment
+                )
 
     @staticmethod
     def _pct_to_decimal(n):
@@ -302,8 +306,9 @@ class SizeParameter(object):
             logger.debug('w %s', self.w)
             logger.debug('h %s', self.h)
             if any((dim <= 0 and dim != None) for dim in (self.w, self.h)):
-                msg = 'Width and height must both be positive numbers'
-                raise RequestException(msg)
+                raise RequestException(
+                    "Width and height must both be positive numbers."
+                )
 
     def _populate_slots_from_pct(self,region_parameter):
         m = SizeParameter.PCT_MODE_REGEX.match(self.uri_value)
@@ -315,8 +320,9 @@ class SizeParameter(object):
         logger.debug('pct_decimal: %s', pct_decimal)
 
         if pct_decimal <= Decimal('0'):
-            msg = 'Percentage supplied is less than 0 (%s).' % (self.uri_value,)
-            raise RequestException(msg)
+            raise RequestException(
+                "Percentage supplied is less than 0 (%r)." % self.uri_value
+            )
 
         w_decimal = region_parameter.pixel_w * pct_decimal
         h_decimal = region_parameter.pixel_h * pct_decimal
@@ -406,8 +412,7 @@ class SizeParameter(object):
             ):
                 return PIXEL_MODE
 
-        message = 'Size syntax %r is not valid' % size_segment
-        raise SyntaxException(message)
+        raise SyntaxException("Size syntax %r is not valid." % size_segment)
 
     def __str__(self):
         return self.uri_value
@@ -445,8 +450,9 @@ class RotationParameter(object):
         match = RotationParameter.ROTATION_REGEX.match(uri_value)
 
         if not match:
-            msg = 'Rotation parameter %r is not a number' % (uri_value,)
-            raise SyntaxException(msg)
+            raise SyntaxException(
+                "Rotation parameter %r is not a number" % uri_value
+            )
 
         self.mirror = bool(match.group('mirror'))
         self.rotation = match.group('rotation')
@@ -454,14 +460,17 @@ class RotationParameter(object):
         try:
             self.canonical_uri_value = '%g' % (float(self.rotation),)
         except ValueError:
-            msg = 'Rotation parameter %r is not a floating point number' % (uri_value,)
-            raise SyntaxException(msg)
+            raise SyntaxException(
+                "Rotation parameter %r is not a floating point number." %
+                uri_value
+            )
 
         if self.mirror:
             self.canonical_uri_value = '!%s' % self.canonical_uri_value
 
         if not 0.0 <= float(self.rotation) <= 360.0:
-            msg = 'Rotation parameter %r is not between 0 and 360' % (uri_value,)
-            raise SyntaxException(msg)
+            raise SyntaxException(
+                "Rotation parameter %r is not between 0 and 360." % uri_value
+            )
 
         logger.debug('Canonical rotation parameter is %s', self.canonical_uri_value)

--- a/loris/parameters.py
+++ b/loris/parameters.py
@@ -118,15 +118,15 @@ class RegionParameter(object):
     def _check_for_oob_errors(self):
         if any(axis < 0 for axis in (self.pixel_x, self.pixel_y)):
             msg = 'x and y region parameters must be 0 or greater (%s)' % (self.uri_value,)
-            raise RequestException(http_status=400, message=msg)
+            raise RequestException(msg)
         if self.decimal_x >= DECIMAL_ONE:
             msg = 'Region x parameter is greater than the width of the image.\n'
             msg +='Image width is %d' % (self.img_info.width,)
-            raise RequestException(http_status=400, message=msg)
+            raise RequestException(msg)
         if self.decimal_y >= DECIMAL_ONE:
             msg = 'Region y parameter is greater than the height of the image.\n'
             msg +='Image height is %d' % (self.img_info.height,)
-            raise RequestException(http_status=400, message=msg)
+            raise RequestException(msg)
 
     def _populate_slots_for_full(self):
         self.canonical_uri_value = FULL_MODE
@@ -150,13 +150,13 @@ class RegionParameter(object):
 
         if len(dimensions) != 4:
             msg = 'Exactly (4) coordinates must be supplied'
-            raise SyntaxException(http_status=400, message=msg)
+            raise SyntaxException(msg)
         if any(n > 100.0 for n in dimensions):
             msg = 'Region percentages must be less than or equal to 100.'
-            raise RequestException(http_status=400, message=msg)
+            raise RequestException(msg)
         if any((n <= 0) for n in dimensions[2:]):
             msg = 'Width and Height Percentages must be greater than 0.'
-            raise RequestException(http_status=400, message=msg)
+            raise RequestException(msg)
 
         # decimals
         self.decimal_x, self.decimal_y, self.decimal_w, \
@@ -186,10 +186,10 @@ class RegionParameter(object):
         dimensions = map(int, self.uri_value.split(','))
         if any(n <= 0 for n in dimensions[2:]):
             msg = 'Width and height must be greater than 0'
-            raise RequestException(http_status=400, message=msg)
+            raise RequestException(msg)
         if len(dimensions) != 4:
             msg = 'Exactly (4) coordinates must be supplied'
-            raise SyntaxException(http_status=400, message=msg)
+            raise SyntaxException(msg)
         return dimensions
 
     def _populate_slots_from_pixels(self, dimensions):
@@ -233,7 +233,7 @@ class RegionParameter(object):
                 return PCT_MODE
             else:
                 msg = 'Region syntax "%s" is not valid' % (region_segment,)
-                raise SyntaxException(http_status=400, message=msg)
+                raise SyntaxException(msg)
 
     @staticmethod
     def _pct_to_decimal(n):
@@ -303,7 +303,7 @@ class SizeParameter(object):
             logger.debug('h %s', self.h)
             if any((dim <= 0 and dim != None) for dim in (self.w, self.h)):
                 msg = 'Width and height must both be positive numbers'
-                raise RequestException(http_status=400, message=msg)
+                raise RequestException(msg)
 
     def _populate_slots_from_pct(self,region_parameter):
         m = SizeParameter.PCT_MODE_REGEX.match(self.uri_value)
@@ -316,7 +316,7 @@ class SizeParameter(object):
 
         if pct_decimal <= Decimal('0'):
             msg = 'Percentage supplied is less than 0 (%s).' % (self.uri_value,)
-            raise RequestException(http_status=400, message=msg)
+            raise RequestException(msg)
 
         w_decimal = region_parameter.pixel_w * pct_decimal
         h_decimal = region_parameter.pixel_h * pct_decimal
@@ -407,7 +407,7 @@ class SizeParameter(object):
                 return PIXEL_MODE
 
         message = 'Size syntax %r is not valid' % size_segment
-        raise SyntaxException(http_status=400, message=message)
+        raise SyntaxException(message)
 
     def __str__(self):
         return self.uri_value
@@ -446,7 +446,7 @@ class RotationParameter(object):
 
         if not match:
             msg = 'Rotation parameter %r is not a number' % (uri_value,)
-            raise SyntaxException(http_status=400, message=msg)
+            raise SyntaxException(msg)
 
         self.mirror = bool(match.group('mirror'))
         self.rotation = match.group('rotation')
@@ -455,13 +455,13 @@ class RotationParameter(object):
             self.canonical_uri_value = '%g' % (float(self.rotation),)
         except ValueError:
             msg = 'Rotation parameter %r is not a floating point number' % (uri_value,)
-            raise SyntaxException(http_status=400, message=msg)
+            raise SyntaxException(msg)
 
         if self.mirror:
             self.canonical_uri_value = '!%s' % self.canonical_uri_value
 
         if not 0.0 <= float(self.rotation) <= 360.0:
             msg = 'Rotation parameter %r is not between 0 and 360' % (uri_value,)
-            raise SyntaxException(http_status=400, message=msg)
+            raise SyntaxException(msg)
 
         logger.debug('Canonical rotation parameter is %s', self.canonical_uri_value)

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -106,7 +106,7 @@ class _AbstractResolver(object):
                 extension = extension.lower()
                 return constants.EXTENSION_MAP.get(extension, extension)
         message = 'Format could not be determined for: %s.' % (ident)
-        raise ResolverException(404, message)
+        raise ResolverException(message)
 
 
 class SimpleFSResolver(_AbstractResolver):
@@ -126,7 +126,7 @@ class SimpleFSResolver(_AbstractResolver):
     def raise_404_for_ident(self, ident):
         message = 'Source image not found for identifier: %s.' % (ident,)
         logger.warn(message)
-        raise ResolverException(404, message)
+        raise ResolverException(message)
 
     def source_file_path(self, ident):
         ident = unquote(ident)
@@ -215,13 +215,13 @@ class SimpleHTTPResolver(_AbstractResolver):
         else:
             message = 'Server Side Error: Configuration incomplete and cannot resolve. Missing setting for cache_root.'
             logger.error(message)
-            raise ResolverException(500, message)
+            raise ResolverException(message)
 
         if not self.uri_resolvable and self.source_prefix == '':
             message = 'Server Side Error: Configuration incomplete and cannot resolve. Must either set uri_resolvable' \
                       ' or source_prefix settings.'
             logger.error(message)
-            raise ResolverException(500, message)
+            raise ResolverException(message)
 
     def request_options(self):
         # parameters to pass to all head and get requests;
@@ -249,10 +249,7 @@ class SimpleHTTPResolver(_AbstractResolver):
             try:
                 (url, options) = self._web_request_url(ident)
             except ResolverException as exc:
-                if exc.http_status == 404:
-                    return False
-                else:
-                    raise
+                return False
 
             try:
                 if self.head_resolvable:
@@ -282,7 +279,7 @@ class SimpleHTTPResolver(_AbstractResolver):
         if not url.startswith(('http://', 'https://')):
             logger.warn('Bad URL request at %s for identifier: %s.', url, ident)
             public_message = 'Bad URL request made for identifier: %s.' % (ident,)
-            raise ResolverException(404, public_message)
+            raise ResolverException(public_message)
         return (url, self.request_options())
 
     # Get a subdirectory structure for the cache_subroot through hashing.
@@ -323,7 +320,7 @@ class SimpleHTTPResolver(_AbstractResolver):
 
     def raise_404_for_ident(self, ident):
         message = 'Image not found for identifier: %s.' % (ident)
-        raise ResolverException(404, message)
+        raise ResolverException(message)
 
     def cached_file_for_ident(self, ident):
         cache_dir = self.cache_dir_path(ident)
@@ -361,7 +358,7 @@ class SimpleHTTPResolver(_AbstractResolver):
                 public_message = 'Source image not found for identifier: %s. Status code returned: %s' % (ident,response.status_code)
                 log_message = 'Source image not found at %s for identifier: %s. Status code returned: %s' % (source_url,ident,response.status_code)
                 logger.warn(log_message)
-                raise ResolverException(404, public_message)
+                raise ResolverException(public_message)
 
             extension = self.cache_file_extension(ident, response)
             local_fp = join(cache_dir, "loris_cache." + extension)
@@ -492,7 +489,7 @@ class TemplateHTTPResolver(SimpleHTTPResolver):
         if ':' not in ident:
             logger.warn('Bad URL request for identifier: %r.', ident)
             public_message = 'Bad URL request made for identifier: %r.' % ident
-            raise ResolverException(404, public_message)
+            raise ResolverException(public_message)
 
         prefix, ident_parts = ident.split(':', 1)
 
@@ -501,7 +498,7 @@ class TemplateHTTPResolver(SimpleHTTPResolver):
         except KeyError:
             logger.warn('No template found for identifier: %r.', ident)
             public_message = 'Bad URL request made for identifier: %r.' % ident
-            raise ResolverException(404, public_message)
+            raise ResolverException(public_message)
 
         try:
             url = url_template % tuple(ident_parts.split(self.config['delimiter']))
@@ -512,7 +509,7 @@ class TemplateHTTPResolver(SimpleHTTPResolver):
             # the template, e.g. '%s' % (1, 2).
             logger.warn('TypeError raised when processing identifier: %r (%r).', (ident, e))
             public_message = 'Bad URL request made for identifier: %r.' % ident
-            raise ResolverException(404, public_message)
+            raise ResolverException(public_message)
 
         # Get the generic options
         options = self.request_options()
@@ -573,7 +570,7 @@ class SourceImageCachingResolver(_AbstractResolver):
         public_message = 'Source image not found for identifier: %s.' % (ident,)
         log_message = 'Source image not found at %s for identifier: %s.' % (source_fp,ident)
         logger.warn(log_message)
-        raise ResolverException(404, public_message)
+        raise ResolverException(public_message)
 
     def resolve(self, app, ident, base_uri):
         if not self.is_resolvable(ident):

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -494,7 +494,6 @@ class TemplateHTTPResolver(SimpleHTTPResolver):
         # ignore other requests (e.g. favicon)
         if ':' not in ident:
             logger.warn('Bad URL request for identifier: %r.', ident)
-            public_message =
             raise ResolverException(
                 "Bad URL request made for identifier: %r." % ident
             )

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -105,8 +105,9 @@ class _AbstractResolver(object):
             if len(extension) < 5:
                 extension = extension.lower()
                 return constants.EXTENSION_MAP.get(extension, extension)
-        message = 'Format could not be determined for: %s.' % (ident)
-        raise ResolverException(message)
+        raise ResolverException(
+            "Format could not be determined for %r." % ident
+        )
 
 
 class SimpleFSResolver(_AbstractResolver):
@@ -278,8 +279,9 @@ class SimpleHTTPResolver(_AbstractResolver):
             url = self.source_prefix + ident + self.source_suffix
         if not url.startswith(('http://', 'https://')):
             logger.warn('Bad URL request at %s for identifier: %s.', url, ident)
-            public_message = 'Bad URL request made for identifier: %s.' % (ident,)
-            raise ResolverException(public_message)
+            raise ResolverException(
+                "Bad URL request made for identifier: %r." % ident
+            )
         return (url, self.request_options())
 
     # Get a subdirectory structure for the cache_subroot through hashing.
@@ -319,8 +321,7 @@ class SimpleHTTPResolver(_AbstractResolver):
         )
 
     def raise_404_for_ident(self, ident):
-        message = 'Image not found for identifier: %s.' % (ident)
-        raise ResolverException(message)
+        raise ResolverException("Image not found for identifier: %r." % ident)
 
     def cached_file_for_ident(self, ident):
         cache_dir = self.cache_dir_path(ident)
@@ -355,10 +356,15 @@ class SimpleHTTPResolver(_AbstractResolver):
 
         with closing(requests.get(source_url, stream=True, **options)) as response:
             if not response.ok:
-                public_message = 'Source image not found for identifier: %s. Status code returned: %s' % (ident,response.status_code)
-                log_message = 'Source image not found at %s for identifier: %s. Status code returned: %s' % (source_url,ident,response.status_code)
-                logger.warn(log_message)
-                raise ResolverException(public_message)
+                logger.warn(
+                    "Source image not found at %s for identifier: %s. "
+                    "Status code returned: %s.",
+                    source_url, ident, response.status_code
+                )
+                raise ResolverException(
+                    "Source image not found for identifier: %s. "
+                    "Status code returned: %s." % (ident, response.status_code)
+                )
 
             extension = self.cache_file_extension(ident, response)
             local_fp = join(cache_dir, "loris_cache." + extension)
@@ -488,8 +494,10 @@ class TemplateHTTPResolver(SimpleHTTPResolver):
         # ignore other requests (e.g. favicon)
         if ':' not in ident:
             logger.warn('Bad URL request for identifier: %r.', ident)
-            public_message = 'Bad URL request made for identifier: %r.' % ident
-            raise ResolverException(public_message)
+            public_message =
+            raise ResolverException(
+                "Bad URL request made for identifier: %r." % ident
+            )
 
         prefix, ident_parts = ident.split(':', 1)
 
@@ -497,8 +505,9 @@ class TemplateHTTPResolver(SimpleHTTPResolver):
             url_template = self.templates[prefix]['url']
         except KeyError:
             logger.warn('No template found for identifier: %r.', ident)
-            public_message = 'Bad URL request made for identifier: %r.' % ident
-            raise ResolverException(public_message)
+            raise ResolverException(
+                "Bad URL request made for identifier: %r." % ident
+            )
 
         try:
             url = url_template % tuple(ident_parts.split(self.config['delimiter']))
@@ -508,8 +517,9 @@ class TemplateHTTPResolver(SimpleHTTPResolver):
             # Raised if there are more parts in the ident than spaces in
             # the template, e.g. '%s' % (1, 2).
             logger.warn('TypeError raised when processing identifier: %r (%r).', (ident, e))
-            public_message = 'Bad URL request made for identifier: %r.' % ident
-            raise ResolverException(public_message)
+            raise ResolverException(
+                "Bad URL request made for identifier: %r." % ident
+            )
 
         # Get the generic options
         options = self.request_options()
@@ -567,10 +577,13 @@ class SourceImageCachingResolver(_AbstractResolver):
 
     def raise_404_for_ident(self, ident):
         source_fp = self.source_file_path(ident)
-        public_message = 'Source image not found for identifier: %s.' % (ident,)
-        log_message = 'Source image not found at %s for identifier: %s.' % (source_fp,ident)
-        logger.warn(log_message)
-        raise ResolverException(public_message)
+        logger.warn(
+            "Source image not found at %s for identifier: %s.",
+            source_fp, ident
+        )
+        raise ResolverException(
+            "Source image not found for identifier: %s." % ident
+        )
 
     def resolve(self, app, ident, base_uri):
         if not self.is_resolvable(ident):

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -161,7 +161,7 @@ class InfoUnit(loris_t.LorisTest):
         fmt = 'invalid_format'
         ident = '01%2f03%2f0001.jpg'
         uri = '%s/%s' % (self.URI_BASE, ident)
-        error_message = 'Didn\'t get a source format, or at least one we recognize ("invalid_format")'
+        error_message = "Didn\'t get a source format, or at least one we recognize ('invalid_format')"
         with self.assertRaises(loris_exception.ImageInfoException) as cm:
             img_info.ImageInfo(self.app, uri, fp, fmt)
         self.assertEqual(cm.exception.message, error_message)

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -161,7 +161,7 @@ class InfoUnit(loris_t.LorisTest):
         fmt = 'invalid_format'
         ident = '01%2f03%2f0001.jpg'
         uri = '%s/%s' % (self.URI_BASE, ident)
-        error_message = "Didn\'t get a source format, or at least one we recognize ('invalid_format')"
+        error_message = "Didn\'t get a source format, or at least one we recognize ('invalid_format')."
         with self.assertRaises(loris_exception.ImageInfoException) as cm:
             img_info.ImageInfo(self.app, uri, fp, fmt)
         self.assertEqual(cm.exception.message, error_message)

--- a/tests/resolver_t.py
+++ b/tests/resolver_t.py
@@ -445,7 +445,6 @@ class Test_TemplateHTTPResolver(object):
         resolver = TemplateHTTPResolver(self.config)
         with pytest.raises(ResolverException) as exc:
             resolver._web_request_url(bad_ident)
-        assert exc.value.http_status == 404
         assert 'Bad URL request' in exc.value.message
 
     delimited_config = {
@@ -477,7 +476,6 @@ class Test_TemplateHTTPResolver(object):
         resolver = TemplateHTTPResolver(self.delimited_config)
         with pytest.raises(ResolverException) as exc:
             resolver._web_request_url(bad_ident)
-        assert exc.value.http_status == 404
         assert 'Bad URL request' in exc.value.message
 
     @pytest.mark.parametrize('config, expected_options',


### PR DESCRIPTION
The value of this attribute is never read except in tests, and setting it on internal exceptions is arguably wrong – it’s a presentation aspect that affects the HTTP response to the user, so should really only be set in `webapp.py` (which is where all the values we actually use are defined!).