### PR TITLE
Move the JP2 Signature/File Type checking into separate methods

### DIFF
--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -19,7 +19,7 @@ except ImportError:  # Python 2
 from PIL import Image
 
 from loris.constants import COMPLIANCE, CONTEXT, OPTIONAL_FEATURES, PROTOCOL
-from loris.jp2_extractor import JP2ExtractorMixin, JP2ExtractionError
+from loris.jp2_extractor import JP2Extractor, JP2ExtractionError
 from loris.loris_exception import ImageInfoException
 from loris.utils import mkdir_p
 
@@ -42,7 +42,7 @@ PIL_MODES_TO_QUALITIES = {
     'F': ['default','color','gray','bitonal']
 }
 
-class ImageInfo(JP2ExtractorMixin, object):
+class ImageInfo(JP2Extractor, object):
     '''Info about the image.
     See: <http://iiif.io/api/image/>
 

--- a/loris/jp2_extractor.py
+++ b/loris/jp2_extractor.py
@@ -57,7 +57,7 @@ def _read_jp2_until_match(jp2, match):
         c = struct.unpack('c', b)[0]
         window.append(c)
 
-    jp2.seek(offset=-len(match), whence=os.SEEK_CUR)
+    jp2.seek(-len(match), os.SEEK_CUR)
 
 
 class JP2Extractor(object):
@@ -118,7 +118,7 @@ class JP2Extractor(object):
         # the box was written (see § I.4), so in that case we page forward
         # until we see 'ihdr', which is the start of the next box.
         if file_type_box_length > 0:
-            jp2.read(file_type_box_length - 12)
+            jp2.read(max(file_type_box_length - 12, 0))
         else:
             _read_jp2_until_match(jp2, b'ihdr')
 

--- a/loris/jp2_extractor.py
+++ b/loris/jp2_extractor.py
@@ -28,7 +28,7 @@ def _parse_length(jp2, box_name):
         return struct.unpack('>I', length_field)[0]
     except struct.error as err:
         raise JP2ExtractionError(
-            "Error reading the length field on the %s box: %r" %
+            "Error reading the length field in the %s box: %r" %
             (box_name, err)
         )
 
@@ -79,13 +79,13 @@ class JP2Extractor(object):
         file_type = jp2.read(4)
         if file_type != b'ftyp':
             raise JP2ExtractionError(
-                "Bad type in File Type box: %r" % file_type
+                "Bad type in the File Type box: %r" % file_type
             )
 
         file_brand = jp2.read(4)
         if file_brand != b'jp2\040':
             raise JP2ExtractionError(
-                "Bad brand in File Type box: %r" % file_brand
+                "Bad brand in the File Type box: %r" % file_brand
             )
 
         # We've already consumed 12 bytes of the box reading the length, type,

--- a/tests/jp2_extractor_t.py
+++ b/tests/jp2_extractor_t.py
@@ -1,0 +1,116 @@
+# -*- encoding: utf-8 -*-
+
+try:
+    from io import BytesIO
+except ImportError:  # Python 2
+    from StringIO import StringIO as BytesIO
+
+from hypothesis import given
+from hypothesis.strategies import binary
+import pytest
+
+from loris.jp2_extractor import JP2Extractor, JP2ExtractionError
+
+
+@pytest.fixture
+def extractor():
+    return JP2Extractor()
+
+
+
+class TestJP2Extractor(object):
+
+    def test_valid_signature_box_is_accepted(self, extractor):
+        extractor._check_signature_box(
+            BytesIO(b'\x00\x00\x00\x0c\x6a\x50\x20\x20\x0d\x0a\x87\x0a')
+        )
+
+    @pytest.mark.parametrize('signature_box', [
+        b'',
+        b'notavalidsignaturebox',
+        b'\x00' * 12,
+    ])
+    def test_invalid_signature_box_is_rejected(self, extractor, signature_box):
+        with pytest.raises(JP2ExtractionError) as err:
+            extractor._check_signature_box(BytesIO(signature_box))
+        assert 'Bad signature box' in err.value.message
+
+    @given(signature_box=binary())
+    def test_check_sig_box_is_ok_or_error(self, extractor, signature_box):
+        try:
+            extractor._check_signature_box(BytesIO(signature_box))
+        except JP2ExtractionError as err:
+            assert 'Bad signature box' in err.message
+
+    def test_valid_file_type_box_is_accepted(self, extractor):
+        extractor._check_file_type_box(BytesIO(b'\x00\x00\x00\x0cftypjp2\040'))
+
+    @pytest.mark.parametrize('file_type_box, exception_message', [
+        # The first four bytes are the length field
+        (b'', 'Error reading the length field in the File Type box'),
+        (b'\x00\x01', 'Error reading the length field in the File Type box'),
+
+        # After the length header, it looks for 'ftyp'
+        (b'\x00\x00\x00\x00FTYP', 'Bad type in the File Type box'),
+        (b'\x00\x00\x00\x00____', 'Bad type in the File Type box'),
+
+        # Then it looks for jp2\040
+        (b'\x00\x00\x00\x00ftypJP2X', 'Bad brand in the File Type box'),
+        (b'\x00\x00\x00\x00ftyp____', 'Bad brand in the File Type box'),
+    ])
+    def test_bad_file_type_box_is_rejected(
+        self, extractor, file_type_box, exception_message
+    ):
+        with pytest.raises(JP2ExtractionError) as err:
+            extractor._check_file_type_box(BytesIO(file_type_box))
+        assert exception_message in err.value.message
+
+    @pytest.mark.parametrize('file_type_box', [
+        # Here we have length 16, so we read four extra bytes from the endf
+        # of the string.
+        b'\x00\x00\x00\x10ftypjp2\040XXXXYYYY',
+
+        # Here we have length 0, so we don't read any extra bytes.
+        b'\x00\x00\x00\x10ftypjp2\040YYYY',
+
+        # Here we have length 8 (too short!), make sure we don't do anything
+        # silly to read extra bytes.
+        b'\x00\x00\x00\x08ftypjp2\040YYYY',
+    ])
+    def test_reads_to_end_of_file_type_box_with_length(
+        self, extractor, file_type_box
+    ):
+        """
+        If a valid length is supplied for the file type box, we correctly
+        read to the end of it before returning.
+        """
+        b = BytesIO(file_type_box)
+        extractor._check_file_type_box(b)
+
+        assert b.read(4) == b'YYYY'
+
+    def test_reads_to_end_of_file_type_box_with_length(self, extractor):
+        # If a valid length is supplied for the file type box, we correctly
+        # read to the end of it before returning.  Here we have length 16,
+        # so we read four extra bytes from the end of the string.
+        b = BytesIO(b'\x00\x00\x00\x10ftypjp2\040XXXXYYYY')
+        extractor._check_file_type_box(b)
+
+        assert b.read(4) == b'YYYY'
+
+    def test_reads_to_end_of_file_type_box_without_length(self, extractor):
+        # If the file type box doesn't have a known length, we read until the
+        # start of the next box, which we know starts with 'ihdr'.  Check we
+        # read to the end of the box, and then rewind to 'ihdr'.
+        b = BytesIO(b'\x00\x00\x00\x00ftypjp2\040XXXXXXXXihdrYYYY')
+        extractor._check_file_type_box(b)
+
+        assert b.read(4) == b'ihdr'
+
+    @given(file_type_box=binary())
+    def test_file_type_box_is_ok_or_error(self, extractor, file_type_box):
+        try:
+            extractor._check_file_type_box(BytesIO(file_type_box))
+        except JP2ExtractionError as err:
+            assert 'File Type box' in err.message
+

--- a/tests/jp2_extractor_t.py
+++ b/tests/jp2_extractor_t.py
@@ -70,8 +70,8 @@ class TestJP2Extractor(object):
         # of the string.
         b'\x00\x00\x00\x10ftypjp2\040XXXXYYYY',
 
-        # Here we have length 0, so we don't read any extra bytes.
-        b'\x00\x00\x00\x10ftypjp2\040YYYY',
+        # Here we have length 12, so we don't read any extra bytes.
+        b'\x00\x00\x00\x0bftypjp2\040YYYY',
 
         # Here we have length 8 (too short!), make sure we don't do anything
         # silly to read extra bytes.

--- a/tests/jp2_extractor_t.py
+++ b/tests/jp2_extractor_t.py
@@ -89,15 +89,6 @@ class TestJP2Extractor(object):
 
         assert b.read(4) == b'YYYY'
 
-    def test_reads_to_end_of_file_type_box_with_length(self, extractor):
-        # If a valid length is supplied for the file type box, we correctly
-        # read to the end of it before returning.  Here we have length 16,
-        # so we read four extra bytes from the end of the string.
-        b = BytesIO(b'\x00\x00\x00\x10ftypjp2\040XXXXYYYY')
-        extractor._check_file_type_box(b)
-
-        assert b.read(4) == b'YYYY'
-
     def test_reads_to_end_of_file_type_box_without_length(self, extractor):
         # If the file type box doesn't have a known length, we read until the
         # start of the next box, which we know starts with 'ihdr'.  Check we

--- a/tests/jp2_extractor_t.py
+++ b/tests/jp2_extractor_t.py
@@ -104,4 +104,3 @@ class TestJP2Extractor(object):
             extractor._check_file_type_box(BytesIO(file_type_box))
         except JP2ExtractionError as err:
             assert 'File Type box' in err.message
-


### PR DESCRIPTION
This is the sort of cleanup alluded to in #387. I’m starting with the first two boxes: the Signature and the File Type. The new methods are fully tested (separating the parser from the disk makes them much easier to test and fuzz), and I’ve added a bunch of explanation and context form the JP2 spec where appropriate.

This implements almost identical logic to the previous check, but failures are more granular, and it’s easier to understand why we're doing these checks.