### PR TITLE
allow '|' characters in identifiers (that's the default delimiter for…

### DIFF
--- a/loris/constants.py
+++ b/loris/constants.py
@@ -37,7 +37,7 @@ EXTENSION_MAP = {
         'tiff': 'tif',
     }
 
-_IDENT = r'(?P<ident>[\w:\-\*\.\%\/]+)'
+_IDENT = r'(?P<ident>[|\w:\-\*\.\%\/]+)'
 _REGION = r'(?P<region>[\w:\.\,]+)'
 _SIZE = r'(?P<size>\!?[\w:\.\,]+)'
 _ROTATION = r'(?P<rotation>\!?\d+\.?\d*)'

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -240,7 +240,7 @@ class ServerSideErrorResponse(LorisResponse):
 
 class LorisRequest(object):
 
-    def __init__(self, request, redirect_id_slash_to_info, proxy_path):
+    def __init__(self, request, redirect_id_slash_to_info=True, proxy_path=None):
         #make sure path is unquoted, so we know what we're working with
         self._path = unquote(request.path)
         self._request = request

--- a/tests/webapp_t.py
+++ b/tests/webapp_t.py
@@ -234,13 +234,13 @@ class TestLorisRequest(TestCase):
         #image request
         path = u'/%s/full/full/0/default.jpg' % identifier
         req = _get_werkzeug_request(path)
-        loris_request = webapp.LorisRequest(req, False, None)
+        loris_request = webapp.LorisRequest(req, redirect_id_slash_to_info=False, proxy_path=None)
         self.assertEqual(loris_request.request_type, u'image')
         self.assertEqual(loris_request.ident, encoded_identifier)
         #info request
         path = u'/%s/info.json' % identifier
         req = _get_werkzeug_request(path)
-        loris_request = webapp.LorisRequest(req, False, None)
+        loris_request = webapp.LorisRequest(req, redirect_id_slash_to_info=False, proxy_path=None)
         self.assertEqual(loris_request.request_type, u'info')
         self.assertEqual(loris_request.ident, encoded_identifier)
 

--- a/tests/webapp_t.py
+++ b/tests/webapp_t.py
@@ -234,13 +234,13 @@ class TestLorisRequest(TestCase):
         #image request
         path = u'/%s/full/full/0/default.jpg' % identifier
         req = _get_werkzeug_request(path)
-        loris_request = webapp.LorisRequest(req, redirect_id_slash_to_info=False, proxy_path=None)
+        loris_request = webapp.LorisRequest(req)
         self.assertEqual(loris_request.request_type, u'image')
         self.assertEqual(loris_request.ident, encoded_identifier)
         #info request
         path = u'/%s/info.json' % identifier
         req = _get_werkzeug_request(path)
-        loris_request = webapp.LorisRequest(req, redirect_id_slash_to_info=False, proxy_path=None)
+        loris_request = webapp.LorisRequest(req)
         self.assertEqual(loris_request.request_type, u'info')
         self.assertEqual(loris_request.ident, encoded_identifier)
 

--- a/tests/webapp_t.py
+++ b/tests/webapp_t.py
@@ -228,6 +228,22 @@ class TestLorisRequest(TestCase):
         self.assertEqual(loris_request.request_type, u'info')
         self.assertEqual(loris_request.ident, encoded_identifier)
 
+    def test_template_delimiter_request(self):
+        identifier = u'a:foo|bar'
+        encoded_identifier = u'a%3Afoo%7Cbar'
+        #image request
+        path = u'/%s/full/full/0/default.jpg' % identifier
+        req = _get_werkzeug_request(path)
+        loris_request = webapp.LorisRequest(req, False, None)
+        self.assertEqual(loris_request.request_type, u'image')
+        self.assertEqual(loris_request.ident, encoded_identifier)
+        #info request
+        path = u'/%s/info.json' % identifier
+        req = _get_werkzeug_request(path)
+        loris_request = webapp.LorisRequest(req, False, None)
+        self.assertEqual(loris_request.request_type, u'info')
+        self.assertEqual(loris_request.ident, encoded_identifier)
+
 
 class TestGetInfo(loris_t.LorisTest):
 


### PR DESCRIPTION
… TemplateHTTPResolver