### PR TITLE
Move the JP2 dimension parsing into a separate method

### DIFF
--- a/loris/jp2_extractor.py
+++ b/loris/jp2_extractor.py
@@ -112,15 +112,16 @@ class JP2Extractor(object):
                 "Bad brand in the File Type box: %r" % file_brand
             )
 
-        # We've already consumed 12 bytes of the box reading the length, type,
-        # and brand fields.  Consume and discard the remaining bytes.
-        # Note: length may be 0 if the length of the box wasn't known when
-        # the box was written (see § I.4), so in that case we page forward
-        # until we see 'ihdr', which is the start of the next box.
+        # After the brand comes the minor version.  We don't care about the
+        # value of this field (it should always be zero, and the spec says to
+        # carry on even if it's not), so just discard those bytes at once.
+        jp2.read(4)
+
+        # We've already consumed 16 bytes of the box reading the length, type,
+        # and brand fields.  If we know the length, we consume any remaining
+        # bytes in this box before returning.
         if file_type_box_length > 0:
-            jp2.read(max(file_type_box_length - 12, 0))
-        else:
-            _read_jp2_until_match(jp2, b'ihdr')
+            jp2.read(max(file_type_box_length - 16, 0))
 
     def extract_jp2(self, jp2):
         """

--- a/loris/jp2_extractor.py
+++ b/loris/jp2_extractor.py
@@ -136,6 +136,8 @@ class JP2Extractor(object):
 
         Starting at the beginning of the Image Header box, this method parses
         the header and returns a tuple (height, width).
+
+        See § I.5.3.1 for details.
         """
         header_box_length = _parse_length(jp2, 'Image Header')
         if header_box_length != 22:
@@ -204,6 +206,7 @@ class JP2Extractor(object):
         # Depending color profiles; there's probably a better way (or more than
         # one, anyway.)
         # see: JP2 I.5.3.3 Colour Specification box
+        window = collections.deque([], 4)
         while ''.join(window) != 'colr':
             b = jp2.read(1)
             c = struct.unpack('c', b)[0]

--- a/tests/jp2_extractor_t.py
+++ b/tests/jp2_extractor_t.py
@@ -103,3 +103,59 @@ class TestJP2Extractor(object):
             extractor._check_file_type_box(BytesIO(file_type_box))
         except JP2ExtractionError as err:
             assert 'File Type box' in err.message
+
+    @pytest.mark.parametrize('header_box_bytes, expected_dimensions', [
+        (b'\x00\x00\x00\x01\x00\x00\x00\x01', (1, 1)),
+        (b'\x00\x00\x00\x11\x00\x00\x00\x00', (17, 0)),
+        (b'\x00\x00\x00\x00\x00\x00\x00\x11', (0, 17)),
+        (b'\x01\x01\x01\x01\x02\x02\x02\x02', (16843009, 33686018)),
+    ])
+    def test_reading_dimensions_from_headr_box(
+        self, extractor, header_box_bytes, expected_dimensions
+    ):
+        b = BytesIO(b'\x00\x00\x00\x16ihdr' + header_box_bytes)
+        dimensions = extractor._get_dimensions_from_image_header_box(b)
+        assert dimensions == expected_dimensions
+
+    @pytest.mark.parametrize('image_header_box, exception_message', [
+        # The first four bytes are the length field
+        (b'', 'Error reading the length field in the Image Header box'),
+        (b'\x00', 'Error reading the length field in the Image Header box'),
+
+        # The length of the Image Header field should always be 22
+        (b'\x00\x00\x00\x00', 'Incorrect length in the Image Header box'),
+        (b'\x00\x00\x01\x01', 'Incorrect length in the Image Header box'),
+        (b'\xff\xff\xff\xff', 'Incorrect length in the Image Header box'),
+
+        # After the length header, it looks for 'ihdr'
+        (b'\x00\x00\x00\x16IHDR', 'Bad type in the Image Header box'),
+        (b'\x00\x00\x00\x16____', 'Bad type in the Image Header box'),
+
+        # After the length and type, not enough data for dimensions
+        (b'\x00\x00\x00\x16ihdr\x00',
+         'Error parsing dimensions in the Image Header box'),
+        (b'\x00\x00\x00\x16ihdr\x00\x00\x00\x00\x01\x01',
+         'Error parsing dimensions in the Image Header box'),
+    ])
+    def test_bad_image_header_box_is_rejected(
+        self, extractor, image_header_box, exception_message
+    ):
+        with pytest.raises(JP2ExtractionError) as err:
+            b = BytesIO(image_header_box)
+            extractor._get_dimensions_from_image_header_box(b)
+        assert exception_message in err.value.message
+
+    @given(image_header_box=binary())
+    def test_image_header_box_is_okay_or_error(
+        self, extractor, image_header_box
+    ):
+        try:
+            dimensions = extractor._get_dimensions_from_image_header_box(
+                BytesIO(image_header_box)
+            )
+        except JP2ExtractionError as err:
+            assert 'Image Header box' in err.message
+        else:
+            assert isinstance(dimensions, tuple)
+            assert len(dimensions) == 2
+            assert all(isinstance(i, int) for i in tuple)


### PR DESCRIPTION
Continues the work started in #387 and #388. Now we unpack the Image Header box, check it's correctly formatted, and read width/height data from it. Plus a stack of extra tests.