### PR TITLE
Refactor the profile data into a structured object

### DIFF
--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -1,4 +1,5 @@
 # img_info.py
+# -*- encoding: utf-8
 
 from __future__ import absolute_import
 

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -54,6 +54,13 @@ class Profile(object):
     description = attr.ib(default=attr.Factory(dict))
 
 
+class EnhancedJSONEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, Profile):
+            return [obj.compliance_uri, obj.description]
+        return obj
+
+
 class ImageInfo(JP2Extractor, object):
     '''Info about the image.
     See: <http://iiif.io/api/image/>
@@ -266,7 +273,7 @@ class ImageInfo(JP2Extractor, object):
 
     def to_iiif_json(self):
         d = self._get_iiif_info()
-        return json.dumps(d)
+        return json.dumps(d, cls=EnhancedJSONEncoder)
 
     def to_full_info_json(self):
         """creates the info JSON that gets cached in the InfoCache"""
@@ -274,7 +281,7 @@ class ImageInfo(JP2Extractor, object):
         d['_src_img_fp'] = self.src_img_fp
         d['_src_format'] = self.src_format
         d['_auth_rules'] = self.auth_rules
-        return json.dumps(d)
+        return json.dumps(d, cls=EnhancedJSONEncoder)
 
 
 class InfoCache(object):

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -45,7 +45,7 @@ PIL_MODES_TO_QUALITIES = {
 }
 
 
-@attr.s
+@attr.s(slots=True)
 class Profile(object):
     """
     Represents a profile, as descriped in § 5.3 of the IIIF Image API spec.

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -149,7 +149,10 @@ class ImageInfo(JP2Extractor, object):
         # we load from the filesystem
         new_inst.tiles = j.get(u'tiles')
         new_inst.sizes = j.get(u'sizes')
-        new_inst.profile = j.get(u'profile')
+
+        profile_args = tuple(j.get(u'profile', []))
+        new_inst.profile = Profile(*profile_args)
+
         new_inst.service = j.get('service', {})
 
         # Also add src_img_fp if available

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -105,8 +105,8 @@ class ImageInfo(JP2Extractor, object):
             # Finish setting up the info from the image file
             self.from_image_file(formats, app.max_size_above_full)
 
-    @staticmethod
-    def from_json_fp(path):
+    @classmethod
+    def from_json_fp(cls, path):
         """Contruct an instance from an existing file.
 
         Args:
@@ -117,7 +117,7 @@ class ImageInfo(JP2Extractor, object):
         """
         with open(path, 'r') as f:
             j = json.load(f)
-        return self.from_json(j)
+        return cls.from_json(j)
 
     @staticmethod
     def from_json(j):

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -16,6 +16,7 @@ try:
 except ImportError:  # Python 2
     from urllib import unquote
 
+import attr
 from PIL import Image
 
 from loris.constants import COMPLIANCE, CONTEXT, OPTIONAL_FEATURES, PROTOCOL
@@ -42,6 +43,16 @@ PIL_MODES_TO_QUALITIES = {
     'F': ['default','color','gray','bitonal']
 }
 
+
+@attr.s
+class Profile(object):
+    """
+    Represents a profile, as descriped in § 5.3 of the IIIF Image API spec.
+    """
+    compliance_uri = attr.ib(default='')
+    description = attr.ib(default=attr.Factory(dict))
+
+
 class ImageInfo(JP2Extractor, object):
     '''Info about the image.
     See: <http://iiif.io/api/image/>
@@ -55,7 +66,8 @@ class ImageInfo(JP2Extractor, object):
         tiles: [{}]
         protocol (str): the protocol URI (constant)
         service (dict): services associated with the image
-        profile []: Features supported by the server/available for this image
+        profile (Profile): Features supported by the server/available for
+            this image
 
         src_img_fp (str): the absolute path on the file system [non IIIF]
         src_format (str): the format of the source image file [non IIIF]

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -57,7 +57,12 @@ class Profile(object):
 class EnhancedJSONEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, Profile):
-            return [obj.compliance_uri, obj.description]
+            # We only include the description in the JSON output if it's
+            # non-empty.
+            if obj.description:
+                return [obj.compliance_uri, obj.description]
+            else:
+                return [obj.compliance_uri]
         return obj
 
 

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -173,10 +173,18 @@ class ImageInfo(JP2Extractor, object):
         self.tiles = []
         self.sizes = None
         self.scaleFactors = None
-        local_profile = {'formats' : formats, 'supports' : OPTIONAL_FEATURES[:]}
-        if max_size_above_full == 0 or max_size_above_full > 100:
-            local_profile['supports'].append('sizeAboveFull')
-        self.profile = [ COMPLIANCE, local_profile ]
+
+        profile_description = {
+            'formats': formats,
+            'supports': OPTIONAL_FEATURES[:],
+        }
+        if (max_size_above_full == 0) or (max_size_above_full > 100):
+            profile_description['supports'].append('sizeAboveFull')
+
+        self.profile = Profile(
+            compliance_uri=COMPLIANCE,
+            description=profile_description
+        )
 
         if self.src_format == 'jp2':
             self._from_jp2(self.src_img_fp)
@@ -196,14 +204,14 @@ class ImageInfo(JP2Extractor, object):
         self.width, self.height = im.size
         self.tiles = []
         self.color_profile_bytes = None
-        self.profile[1]['qualities'] = PIL_MODES_TO_QUALITIES[im.mode]
+        self.profile.description['qualities'] = PIL_MODES_TO_QUALITIES[im.mode]
         self.sizes = []
 
     def _from_jp2(self, fp):
         '''Get info about a JP2.
         '''
         logger.debug('Extracting info from JP2 file: %s' % fp)
-        self.profile[1]['qualities'] = ['default', 'bitonal']
+        self.profile.description['qualities'] = ['default', 'bitonal']
 
         with open(fp, 'rb') as jp2:
             try:
@@ -223,7 +231,7 @@ class ImageInfo(JP2Extractor, object):
 
         # This is an assumption for now (i.e. that if you have a colour profile
         # embedded, you're probably working with color images.
-        self.profile[1]['qualities'] += ['gray', 'color']
+        self.profile.description['qualities'] += ['gray', 'color']
 
     def sizes_for_scales(self, scales):
         fn = ImageInfo.scale_dim

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -106,7 +106,7 @@ class ImageInfo(JP2Extractor, object):
             self.from_image_file(formats, app.max_size_above_full)
 
     @staticmethod
-    def from_json(path):
+    def from_json_fp(path):
         """Contruct an instance from an existing file.
 
         Args:
@@ -115,9 +115,19 @@ class ImageInfo(JP2Extractor, object):
         Raises:
             Exception
         """
-        new_inst = ImageInfo()
         with open(path, 'r') as f:
             j = json.load(f)
+        return self.from_json(j)
+
+    @staticmethod
+    def from_json(j):
+        """Construct an instance from a JSON string.
+
+        Args:
+            j (str): A valid JSON string.
+
+        """
+        new_inst = ImageInfo()
 
         new_inst.ident = j.get(u'@id')
         new_inst.width = j.get(u'width')
@@ -313,7 +323,7 @@ class InfoCache(object):
             info_fp = self._get_info_fp(request)
             if os.path.exists(info_fp):
                 # from fs
-                info = ImageInfo.from_json(info_fp)
+                info = ImageInfo.from_json_fp(info_fp)
 
                 icc_fp = self._get_color_profile_fp(request)
                 if os.path.exists(icc_fp):

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -116,11 +116,10 @@ class ImageInfo(JP2Extractor, object):
             Exception
         """
         with open(path, 'r') as f:
-            j = json.load(f)
-        return cls.from_json(j)
+            return cls.from_json(f.read())
 
     @staticmethod
-    def from_json(j):
+    def from_json(json_string):
         """Construct an instance from a JSON string.
 
         Args:
@@ -128,6 +127,7 @@ class ImageInfo(JP2Extractor, object):
 
         """
         new_inst = ImageInfo()
+        j = json.loads(json_string)
 
         new_inst.ident = j.get(u'@id')
         new_inst.width = j.get(u'width')

--- a/loris/jp2_extractor.py
+++ b/loris/jp2_extractor.py
@@ -227,9 +227,9 @@ class JP2Extractor(object):
             logger.debug('Image contains an enumerated colourspace: %d', enum_cs)
             logger.debug('Enumerated colourspace: %d', enum_cs)
             if enum_cs == 16: # sRGB
-                self.profile[1]['qualities'] += ['gray', 'color']
+                self.profile.description['qualities'] += ['gray', 'color']
             elif enum_cs == 17: # grayscale
-                self.profile[1]['qualities'] += ['gray']
+                self.profile.description['qualities'] += ['gray']
             elif enum_cs == 18: # sYCC
                 pass
             else:
@@ -249,7 +249,7 @@ class JP2Extractor(object):
             if colr_meth <= 4 and -128 <= colr_prec <= 127 and 1 <= colr_approx <= 4:
                 self.assign_color_profile(jp2)
 
-        logger.debug('qualities: %s', self.profile[1]['qualities'])
+        logger.debug('qualities: %s', self.profile.description['qualities'])
 
         window =  deque(jp2.read(2), 2)
         # start of codestream

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -623,7 +623,7 @@ class Loris(object):
                 image_request.info = info
 
                 # 3. Check that we can make the quality requested
-                if image_request.quality not in info.profile[1]['qualities']:
+                if image_request.quality not in info.profile.description['qualities']:
                     return BadRequestResponse('"%s" quality is not available for this image' % (image_request.quality,))
 
                 # 4. Check if requested size is allowed

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ requests >= 2.12.0
 netaddr >= 0.7.19
 pyjwt >= 1.5.2
 cryptography >= 2.0.3
-
+attrs >= 17.3.0

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -77,7 +77,7 @@ class InfoUnit(loris_t.LorisTest):
 
         self.app.max_size_above_full = 0
         info = img_info.ImageInfo(self.app, uri, fp, fmt)
-        self.assertTrue('sizeAboveFull' in info.profile[1]['supports'])
+        self.assertTrue('sizeAboveFull' in info.profile.description['supports'])
         self.app.max_size_above_full = 200
 
 

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -332,6 +332,45 @@ class TestImageInfo(object):
         with pytest.raises(ImageInfoException) as exc:
             info.from_image_file()
 
+    def test_profile_from_json_no_profile(self):
+        existing_info = {}
+        info = ImageInfo.from_json(json.dumps(existing_info))
+
+        assert info.profile.compliance_uri == ''
+        assert info.profile.description == {}
+
+    def test_profile_from_json_one_arg_profile(self):
+        compliance_uri = 'http://iiif.io/api/image/2/level2.json'
+        existing_info = {
+            'profile': [compliance_uri]
+        }
+        info = ImageInfo.from_json(json.dumps(existing_info))
+
+        assert info.profile.compliance_uri == compliance_uri
+        assert info.profile.description == {}
+
+    def test_profile_from_json_two_arg_profile(self):
+        compliance_uri = 'http://iiif.io/api/image/2/level2.json'
+        description = {
+            'formats': ['jpg', 'png', 'gif', 'webp'],
+            'qualities': ['default', 'bitonal', 'gray', 'color'],
+            'supports': [
+                'canonicalLinkHeader',
+                'profileLinkHeader',
+                'mirroring',
+                'rotationArbitrary',
+                'sizeAboveFull',
+                'regionSquare'
+            ]
+        }
+        existing_info = {
+            'profile': [compliance_uri, description]
+        }
+        info = ImageInfo.from_json(json.dumps(existing_info))
+
+        assert info.profile.compliance_uri == compliance_uri
+        assert info.profile.description == description
+
 
 class TestProfile(object):
 

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -374,28 +374,44 @@ class TestImageInfo(object):
 
 class TestProfile(object):
 
+    compliance_uri = 'http://iiif.io/api/image/2/level2.json'
+    description = {
+        'formats': ['gif', 'pdf'],
+        'qualities': ['color', 'gray'],
+        'maxWidth': 2000,
+        'supports': ['canonicalLinkHeader', 'rotationArbitrary']
+    }
+
     def test_construct_no_args(self):
         p = Profile()
         assert p.compliance_uri == ''
         assert p.description == {}
 
     def test_construct_one_args(self):
-        compliance_uri = 'http://iiif.io/api/image/2/level2.json'
-        p = Profile(compliance_uri)
-        assert p.compliance_uri == compliance_uri
+        p = Profile(self.compliance_uri)
+        assert p.compliance_uri == self.compliance_uri
         assert p.description == {}
 
     def test_construct_two_args(self):
-        compliance_uri = 'http://iiif.io/api/image/2/level2.json'
-        description = {
-            'formats': ['gif', 'pdf'],
-            'qualities': ['color', 'gray'],
-            'maxWidth': 2000,
-            'supports': ['canonicalLinkHeader', 'rotationArbitrary']
-        }
-        p = Profile(compliance_uri, description)
-        assert p.compliance_uri == compliance_uri
-        assert p.description == description
+        p = Profile(self.compliance_uri, self.description)
+        assert p.compliance_uri == self.compliance_uri
+        assert p.description == self.description
+
+    def test_json_encoding_with_no_description(self):
+        p = Profile(self.compliance_uri)
+        json_string = json.dumps(
+            {'profile': p}, cls=img_info.EnhancedJSONEncoder
+        )
+        assert json.loads(json_string)['profile'] == [self.compliance_uri]
+
+    def test_json_encoding_with_description(self):
+        p = Profile(self.compliance_uri, self.description)
+        json_string = json.dumps(
+            {'profile': p}, cls=img_info.EnhancedJSONEncoder
+        )
+        assert json.loads(json_string)['profile'] == [
+            self.compliance_uri, self.description
+        ]
 
 
 class InfoFunctional(loris_t.LorisTest):

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -69,7 +69,8 @@ class InfoUnit(loris_t.LorisTest):
 
         self.assertEqual(info.width, self.test_jp2_color_dims[0])
         self.assertEqual(info.height, self.test_jp2_color_dims[1])
-        self.assertEqual(info.profile, profile)
+        self.assertEqual(info.profile.compliance_uri, profile[0])
+        self.assertEqual(info.profile.description, profile[1])
         self.assertEqual(info.tiles, self.test_jp2_color_tiles)
         self.assertEqual(info.sizes, self.test_jp2_color_sizes)
         self.assertEqual(info.ident, uri)
@@ -141,7 +142,8 @@ class InfoUnit(loris_t.LorisTest):
 
         self.assertEqual(info.width, self.test_jp2_gray_dims[0])
         self.assertEqual(info.height, self.test_jp2_gray_dims[1])
-        self.assertEqual(info.profile, profile)
+        self.assertEqual(info.profile.compliance_uri, profile[0])
+        self.assertEqual(info.profile.description, profile[1])
         self.assertEqual(info.tiles, self.test_jp2_gray_tiles)
         self.assertEqual(info.sizes, self.test_jp2_gray_sizes)
         self.assertEqual(info.ident, uri)
@@ -190,7 +192,8 @@ class InfoUnit(loris_t.LorisTest):
 
         self.assertEqual(info.width, self.test_jpeg_dims[0])
         self.assertEqual(info.height, self.test_jpeg_dims[1])
-        self.assertEqual(info.profile, profile)
+        self.assertEqual(info.profile.compliance_uri, profile[0])
+        self.assertEqual(info.profile.description, profile[1])
         self.assertEqual(info.sizes, self.test_jpeg_sizes)
         self.assertEqual(info.ident, uri)
         self.assertEqual(info.protocol, PROTOCOL)
@@ -219,7 +222,8 @@ class InfoUnit(loris_t.LorisTest):
 
         self.assertEqual(info.width, self.test_png_dims[0])
         self.assertEqual(info.height, self.test_png_dims[1])
-        self.assertEqual(info.profile, profile)
+        self.assertEqual(info.profile.compliance_uri, profile[0])
+        self.assertEqual(info.profile.description, profile[1])
         self.assertEqual(info.sizes, self.test_png_sizes)
         self.assertEqual(info.ident, uri)
         self.assertEqual(info.protocol, PROTOCOL)
@@ -250,7 +254,8 @@ class InfoUnit(loris_t.LorisTest):
         self.assertEqual(info.width, self.test_tiff_dims[0])
         self.assertEqual(info.height, self.test_tiff_dims[1])
         self.assertEqual(info.sizes, self.test_tiff_sizes)
-        self.assertEqual(info.profile, profile)
+        self.assertEqual(info.profile.compliance_uri, profile[0])
+        self.assertEqual(info.profile.description, profile[1])
         self.assertEqual(info.ident, uri)
         self.assertEqual(info.protocol, PROTOCOL)
 

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -257,7 +257,7 @@ class InfoUnit(loris_t.LorisTest):
     def test_info_from_json(self):
         json_fp = self.test_jp2_color_info_fp
 
-        info = img_info.ImageInfo.from_json(json_fp)
+        info = img_info.ImageInfo.from_json_fp(json_fp)
 
         profile = ["http://iiif.io/api/image/2/level2.json", {
                 "formats": [ "jpg", "png", "gif", "webp" ],
@@ -352,7 +352,7 @@ class InfoFunctional(loris_t.LorisTest):
             }
         ]
 
-        info = img_info.ImageInfo.from_json(tmp_fp)
+        info = img_info.ImageInfo.from_json_fp(tmp_fp)
         self.assertEqual(info.width, self.test_jp2_color_dims[0])
         self.assertEqual(info.height, self.test_jp2_color_dims[1])
         self.assertEqual(info.profile, profile)

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -18,7 +18,7 @@ from werkzeug.datastructures import Headers
 
 from loris import img_info, loris_exception
 from loris.constants import PROTOCOL
-from loris.img_info import ImageInfo
+from loris.img_info import ImageInfo, Profile
 from loris.loris_exception import ImageInfoException
 from tests import loris_t, webapp_t
 
@@ -325,6 +325,32 @@ class TestImageInfo(object):
         info = ImageInfo(src_format=src_format)
         with pytest.raises(ImageInfoException) as exc:
             info.from_image_file()
+
+
+class TestProfile(object):
+
+    def test_construct_no_args(self):
+        p = Profile()
+        assert p.compliance_uri == ''
+        assert p.description == {}
+
+    def test_construct_one_args(self):
+        compliance_uri = 'http://iiif.io/api/image/2/level2.json'
+        p = Profile(compliance_uri)
+        assert p.compliance_uri == compliance_uri
+        assert p.description == {}
+
+    def test_construct_two_args(self):
+        compliance_uri = 'http://iiif.io/api/image/2/level2.json'
+        description = {
+            'formats': ['gif', 'pdf'],
+            'qualities': ['color', 'gray'],
+            'maxWidth': 2000,
+            'supports': ['canonicalLinkHeader', 'rotationArbitrary']
+        }
+        p = Profile(compliance_uri, description)
+        assert p.compliance_uri == compliance_uri
+        assert p.description == description
 
 
 class InfoFunctional(loris_t.LorisTest):

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -275,7 +275,8 @@ class InfoUnit(loris_t.LorisTest):
 
         self.assertEqual(info.width, self.test_jp2_color_dims[0])
         self.assertEqual(info.height, self.test_jp2_color_dims[1])
-        self.assertEqual(info.profile, profile)
+        self.assertEqual(info.profile.compliance_uri, profile[0])
+        self.assertEqual(info.profile.description, profile[1])
         self.assertEqual(info.tiles, self.test_jp2_color_tiles)
         self.assertEqual(info.ident, self.test_jp2_color_uri)
         self.assertEqual(info.sizes, self.test_jp2_color_sizes)
@@ -381,7 +382,8 @@ class InfoFunctional(loris_t.LorisTest):
         info = img_info.ImageInfo.from_json_fp(tmp_fp)
         self.assertEqual(info.width, self.test_jp2_color_dims[0])
         self.assertEqual(info.height, self.test_jp2_color_dims[1])
-        self.assertEqual(info.profile, profile)
+        self.assertEqual(info.profile.compliance_uri, profile[0])
+        self.assertEqual(info.profile.description, profile[1])
         self.assertEqual(info.tiles, self.test_jp2_color_tiles)
         self.assertEqual(info.ident, self.test_jp2_color_uri)
 

--- a/tests/webapp_t.py
+++ b/tests/webapp_t.py
@@ -353,7 +353,7 @@ class WebappIntegration(loris_t.LorisTest):
         with open(tmp_fp, 'wb') as f:
             f.write(resp.data)
 
-        info = img_info.ImageInfo.from_json(tmp_fp)
+        info = img_info.ImageInfo.from_json_fp(tmp_fp)
         self.assertEqual(info.width, self.test_jp2_color_dims[0])
 
     def test_info_without_dot_json_404(self):


### PR DESCRIPTION
The `profile` field is a list that contains a compliance URI and a structured object, which is how it’s represented in an `info.json` blob – but that leads to somewhat weird-looking code like:

```python
self.profile[1]['qualities'] += ['gray', 'color']
```

I think it’s clearer to write:

```python
self.profile.description['qualities'] += ['gray', 'color']
```

This is the refactoring that arose from trying to do that, plus the usual battery of extra tests.

---

Some notes:

* We're trading some extra complexity in `img_info.py` for cleaner code elsewhere. That’s not a definite win, but I think it’s at least worth consideration.

* I split out `from_json()` into two method: one that just takes JSON strings, another that reads them from disk. This makes writing tests easier.

* This adds a new dependency on [attrs](https://pypi.org/project/attrs/), because I didn't want to write any class boilerplate. I find attrs pretty useful, and if we’re happy to add it as dependency (pure Python), I think it might be useful elsewhere.