### PR TITLE
Jp2 color spec box

### DIFF
--- a/loris/jp2_extractor.py
+++ b/loris/jp2_extractor.py
@@ -201,7 +201,7 @@ class JP2Extractor(object):
         colour_box_length = _parse_length(jp2, 'Colour Specification')
 
         colour_box_type = jp2.read(4)
-        if header_box_type != b'colr':
+        if colour_box_type != b'colr':
             raise JP2ExtractionError(
                 "Bad type in the Colour Specification box: %r" %
                 colour_box_type
@@ -220,7 +220,7 @@ class JP2Extractor(object):
         logger.debug('colr METH:   %d', meth)
 
         if meth not in (1, 2):
-            return
+            return ([], None)
 
         # Then read PREC and APPROX.  For both fields, the spec says the
         # value should be zero, and "conforming readers shall ignore
@@ -274,6 +274,10 @@ class JP2Extractor(object):
             # We're assuming that if you have an embedded colour profile,
             # you're working with colour images.
             return (['gray', 'color'], profile_bytes)
+
+        # This should be unreachable; we include it for completeness.
+        else:
+            assert False, meth
 
     def extract_jp2(self, jp2):
         """


### PR DESCRIPTION
Building on #391 and in the vein of #387/#388, this patch moves the parsing of the Colour Specification box into its own method, and adds another set of additional tests and fuzzing.

As before, I’m trying to:

* Make this code really easy to test and fuzz, by making everything pure functions
* Extend the existing comments so a reader can see how the code matches the spec