### PR TITLE
Fixing fallback logic in loris.utils.safe_rename

### DIFF
--- a/loris/utils.py
+++ b/loris/utils.py
@@ -78,7 +78,8 @@ def safe_rename(src, dst):
             # atomic.  We intersperse a random UUID so if different processes
             # are copying into `<dst>`, they don't overlap in their tmp copies.
             mole_id = uuid.uuid4()
-            tmp_dst = shutil.copyfile(src, '%s.%s.tmp' % (dst, mole_id))
+            tmp_dst = '%s.%s.tmp' % (dst, mole_id)
+            shutil.copyfile(src, tmp_dst)
 
             # Then do an atomic rename onto the new name, and clean up the
             # source image.


### PR DESCRIPTION
[shutil.copyfile()](https://docs.python.org/2/library/shutil.html#shutil.copyfile) returns None, not a string, resulting in the following call to [os.rename()](https://docs.python.org/2/library/os.html#os.rename) blowing up in the event you end up in this except block.

This fix splits the generation of the tmp_dst string into a separate assignment, and then uses that string in the following calls to both copyfile() and rename()