### PR TITLE
Memory cache off-by-one error

### DIFF
--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -408,11 +408,12 @@ class InfoCache(object):
             logger.debug('Created %s', icc_fp)
 
         # into mem
-        lastmod = datetime.utcfromtimestamp(os.path.getmtime(info_fp))
-        with self._lock:
-            self._dict[request.url] = (info,lastmod)
-            while len(self._dict) > self.size:
-                self._dict.popitem(last=False)
+        if self.size > 0:
+            lastmod = datetime.utcfromtimestamp(os.path.getmtime(info_fp))
+            with self._lock:
+                self._dict[request.url] = (info,lastmod)
+                while len(self._dict) > self.size:
+                    self._dict.popitem(last=False)
 
     def __delitem__(self, request):
         with self._lock:

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -372,7 +372,7 @@ class InfoCache(object):
                 info_and_lastmod = (info, lastmod)
                 logger.debug('Info for %s read from file system', request)
                 # into mem:
-                self.__setitem__(request, info)
+                self.__setitem__(request, info, _to_fs=False)
         return info_and_lastmod
 
     def has_key(self, request):
@@ -388,26 +388,31 @@ class InfoCache(object):
         else:
             return info_lastmod
 
-    def __setitem__(self, request, info):
-        # to fs
-        logger.debug('request passed to __setitem__: %s', request)
+    def __setitem__(self, request, info, _to_fs=True):
         info_fp = self._get_info_fp(request)
-        dp = os.path.dirname(info_fp)
-        mkdir_p(dp)
-        logger.debug('Created %s', dp)
+        if _to_fs:
+            # to fs
+            logger.debug('request passed to __setitem__: %s', request)
+            dp = os.path.dirname(info_fp)
+            mkdir_p(dp)
+            logger.debug('Created %s', dp)
 
-        with open(info_fp, 'w') as f:
-            f.write(info.to_full_info_json())
-        logger.debug('Created %s', info_fp)
+            with open(info_fp, 'w') as f:
+                f.write(info.to_full_info_json())
+            logger.debug('Created %s', info_fp)
 
 
-        if info.color_profile_bytes:
-            icc_fp = self._get_color_profile_fp(request)
-            with open(icc_fp, 'wb') as f:
-                f.write(info.color_profile_bytes)
-            logger.debug('Created %s', icc_fp)
+            if info.color_profile_bytes:
+                icc_fp = self._get_color_profile_fp(request)
+                with open(icc_fp, 'wb') as f:
+                    f.write(info.color_profile_bytes)
+                logger.debug('Created %s', icc_fp)
 
         # into mem
+        # The info file cache on disk must already exist before
+        # this is called - it's where the mtime gets drawn from.
+        # aka, nothing outside of this class should be using
+        # to_fs=False
         if self.size > 0:
             lastmod = datetime.utcfromtimestamp(os.path.getmtime(info_fp))
             with self._lock:

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -411,7 +411,7 @@ class InfoCache(object):
         # into mem
         lastmod = datetime.utcfromtimestamp(os.path.getmtime(info_fp))
         with self._lock:
-            while len(self._dict) >= self.size:
+            while len(self._dict) > self.size:
                 self._dict.popitem(last=False)
             self._dict[request.url] = (info,lastmod)
 

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -372,8 +372,7 @@ class InfoCache(object):
                 info_and_lastmod = (info, lastmod)
                 logger.debug('Info for %s read from file system', request)
                 # into mem:
-                self._dict[request.url] = info_and_lastmod
-
+                self.__setitem__(request, info)
         return info_and_lastmod
 
     def has_key(self, request):
@@ -411,9 +410,9 @@ class InfoCache(object):
         # into mem
         lastmod = datetime.utcfromtimestamp(os.path.getmtime(info_fp))
         with self._lock:
+            self._dict[request.url] = (info,lastmod)
             while len(self._dict) > self.size:
                 self._dict.popitem(last=False)
-            self._dict[request.url] = (info,lastmod)
 
     def __delitem__(self, request):
         with self._lock:

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -513,6 +513,30 @@ class TestInfoCache(loris_t.LorisTest):
         cache = img_info.InfoCache(root=self.SRC_IMAGE_CACHE)
         assert len(cache) == 0
 
+    def test_cache_limit(self):
+        cache = img_info.InfoCache(root=self.SRC_IMAGE_CACHE, size=2)
+        self.app.info_cache = cache
+        request_uris = [
+            '/%s/%s' % (self.test_jp2_color_id,'info.json'),
+            '/%s/%s' % (self.test_jpeg_id,'info.json'),
+            '/%s/%s' % (self.test_png_id,'info.json'),
+            '/%s/%s' % (self.test_jp2_gray_id,'info.json')
+        ]
+        for x in request_uris:
+            resp = self.client.get(x)
+
+        # Check we only cache two
+        assert len(self.app.info_cache) == 2
+
+    def test_no_cache(self):
+        cache = img_info.InfoCache(root=self.SRC_IMAGE_CACHE, size=0)
+        self.app.info_cache = cache
+        request_uri = '/%s/%s' % (self.test_jp2_color_id,'info.json')
+        resp = self.client.get(request_uri)
+        print(self.app.info_cache._dict)
+
+        assert len(self.app.info_cache) == 0
+
     def test_deleting_cache_item_removes_color_profile_fp(self):
         # First assemble the cache
         cache, req = self._cache_with_request()


### PR DESCRIPTION
Current handling of the in memory cache in InfoCache has an off-by-one in the while loop condition. In cases where size > 0 the cache would (harmlessly, I believe) just be one smaller than stated in the size parameter. In cases where size == 0 we were getting ```StopIteration``` exceptions in production, though in my own testing I could only get ```KeyError: 'dictionary is empty'```

This PR changes the while loop condition to strictly ```>```, rather than ```>=```