### PR TITLE
Fixes for installing in Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -170,6 +170,10 @@ from loris.webapp import create_app
 # site.addsitedir('/path/to/my/virtualenv/lib/python2.x/site-packages')
 application = create_app(config_file_path='%s')
 ''' % (config_file_path,)
+
+        from loris.utils import mkdir_p
+        mkdir_p(self.www_dir)
+
         with open(wsgi_file_path, 'w') as f:
             f.write(content)
         os.chmod(wsgi_file_path, 0o755)

--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,8 @@ Please create this user, e.g.:
             self.log_dir,
             self.config_dir
         ]
-        map(self.__init_dir, loris_directories)
+        for d in loris_directories:
+            self.__init_dir(d)
 
     def __init_dir(self, d):
         # Could do something here to warn if dir exists but permissions or
@@ -175,9 +176,6 @@ from loris.webapp import create_app
 # site.addsitedir('/path/to/my/virtualenv/lib/python2.x/site-packages')
 application = create_app(config_file_path='%s')
 ''' % (config_file_path,)
-
-        from loris.utils import mkdir_p
-        mkdir_p(self.www_dir)
 
         with open(wsgi_file_path, 'w') as f:
             f.write(content)

--- a/setup.py
+++ b/setup.py
@@ -156,8 +156,8 @@ Please create this user, e.g.:
 
         s = os.stat(d)
         permissions = oct(stat.S_IMODE(s.st_mode))
-        if permissions != oct(0755):
-            os.chmod(d, 0755)
+        if permissions != oct(0o755):
+            os.chmod(d, 0o755)
             stdout.write('Set permissions for %s to 0755\n' % (d,))
 
     def __write_wsgi(self):
@@ -172,7 +172,7 @@ application = create_app(config_file_path='%s')
 ''' % (config_file_path,)
         with open(wsgi_file_path, 'w') as f:
             f.write(content)
-        os.chmod(wsgi_file_path, 0755)
+        os.chmod(wsgi_file_path, 0o755)
         os.chown(wsgi_file_path, self.loris_owner_id, self.loris_group_id)
     @property
     def __here(self):
@@ -189,7 +189,7 @@ application = create_app(config_file_path='%s')
         shutil.copyfile(index_src, index_target)
         shutil.copyfile(favicon_src, favicon_target)
         for f in (index_target, favicon_target):
-            os.chmod(f, 0644)
+            os.chmod(f, 0o644)
             os.chown(f, self.loris_owner_id, self.loris_group_id)
 
     def __update_and_deploy_config(self):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # setup.py
+
+from __future__ import print_function
+
 from grp import getgrnam
 from pwd import getpwnam
 from setuptools import setup
@@ -149,10 +152,12 @@ Please create this user, e.g.:
         # ownership aren't sufficient.
         if not os.path.exists(d):
             os.makedirs(d)
-            stdout.write('Created %s\n' % (d,))
+            print('Created %s' % d)
             os.chown(d, self.loris_owner_id, self.loris_group_id)
-            stdout.write('Changed ownership of %s to %s:%s\n' %
-                (d,self.loris_owner,self.loris_group))
+            print(
+                'Changed ownership of %s to %s:%s' %
+                (d, self.loris_owner, self.loris_group)
+            )
 
         s = os.stat(d)
         permissions = oct(stat.S_IMODE(s.st_mode))

--- a/setup.py
+++ b/setup.py
@@ -235,7 +235,7 @@ setup(
     license='Simplified BSD',
     version=VERSION,
     packages=['loris'],
-    install_requires=install_requires
+    install_requires=[str(ir.req) for ir in install_requires]
 )
 
 


### PR DESCRIPTION
I've been trying to install Loris with Python 3, and ran into a bunch of hiccups in setup.py. This was enough to get it working in my setup.

Longer term, we should think about if we can test setup.py in CI.