### PR TITLE
Improve the logging when sRGB conversion fails

### DIFF
--- a/loris/transforms.py
+++ b/loris/transforms.py
@@ -137,7 +137,10 @@ class _AbstractTransformer(object):
                 embedded_profile = BytesIO(im.info['icc_profile'])
                 im = self._map_im_profile_to_srgb(im, embedded_profile)
         except PyCMSError as err:
-            logger.warn('Error converting %r to sRGB: %r', im, err)
+            logger.warn(
+                'Error converting %r (%r) to sRGB: %r',
+                image_request.ident, image_info.src_img_fp, err
+            )
 
         if rotation_param.rotation != '0' and rotate:
             r = 0 - float(rotation_param.rotation)


### PR DESCRIPTION
The current log spits out something like:

```
2018-03-26 19:42:38,155 (loris.transforms) [WARNING]: Error converting <PIL.Image.Image image mode=L size=180x267 at 0x7FB61BA2BF28> to sRGB: PyCMSError(ValueError('cannot build transform',),)
```

which isn't very helpful in identifying problem files. This patch modifies the log message to include the name of the public ident and source file for easier debugging.