### PR TITLE
Allow TIFF as an output format

### DIFF
--- a/etc/loris2.conf
+++ b/etc/loris2.conf
@@ -58,7 +58,7 @@ format = '%(asctime)s (%(name)s) [%(levelname)s]: %(message)s'
 [resolver]
 impl = 'loris.resolver.SimpleFSResolver'
 src_img_root = '/usr/local/share/images' # r--
-cache_root='/tmp/loris/tmp'
+
 #Example of one version of SimpleHTTResolver config
 
 #[resolver]

--- a/etc/loris2.conf
+++ b/etc/loris2.conf
@@ -58,7 +58,7 @@ format = '%(asctime)s (%(name)s) [%(levelname)s]: %(message)s'
 [resolver]
 impl = 'loris.resolver.SimpleFSResolver'
 src_img_root = '/usr/local/share/images' # r--
-
+cache_root='/tmp/loris/tmp'
 #Example of one version of SimpleHTTResolver config
 
 #[resolver]
@@ -104,6 +104,7 @@ cache_dp = '/var/cache/loris' # rwx
 
 [transforms]
 dither_bitonal_images = False
+# To enable TIFF output, add "tif" here:
 target_formats = ['jpg','png','gif','webp']
 
     [[jpg]]

--- a/loris/transforms.py
+++ b/loris/transforms.py
@@ -195,6 +195,10 @@ class _AbstractTransformer(object):
             # see http://pillow.readthedocs.org/en/latest/handbook/image-file-formats.html#webp
             im.save(target_fp, quality=90)
 
+        elif image_request.format == 'tif':
+            # see http://pillow.readthedocs.io/en/latest/handbook/image-file-formats.html#tiff
+            im.save(target_fp, compression='None')
+
 
 class _PillowTransformer(_AbstractTransformer):
     def transform(self, target_fp, image_request, image_info):

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -65,6 +65,8 @@ def get_debug_config(debug_jp2_transformer):
     config['img_info.InfoCache']['cache_dp'] = '/tmp/loris/cache/info'
     config['resolver']['impl'] = 'loris.resolver.SimpleFSResolver'
     config['resolver']['src_img_root'] = path.join(project_dp,'tests','img')
+    config['transforms']['target_formats'] = [ 'jpg', 'png', 'gif', 'webp', 'tif']
+    
     if debug_jp2_transformer == 'opj':
         from loris.transforms import OPJ_JP2Transformer
         config['transforms']['jp2']['impl'] = 'OPJ_JP2Transformer'

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -47,7 +47,7 @@ class InfoUnit(loris_t.LorisTest):
         uri = self.test_jp2_color_uri
 
         profile = ["http://iiif.io/api/image/2/level2.json", {
-                "formats": [ "jpg", "png", "gif", "webp" ],
+                "formats": [ "jpg", "png", "gif", "webp", "tif" ],
                 "qualities": [
                     "default",
                     "bitonal",
@@ -122,7 +122,7 @@ class InfoUnit(loris_t.LorisTest):
         uri = self.test_jp2_gray_uri
 
         profile = ["http://iiif.io/api/image/2/level2.json", {
-            "formats": [ "jpg", "png", "gif", "webp" ],
+            "formats": [ "jpg", "png", "gif", "webp", "tif" ],
             "qualities": [
                 "default",
                 "bitonal",
@@ -178,7 +178,7 @@ class InfoUnit(loris_t.LorisTest):
         info = img_info.ImageInfo(self.app, uri, fp, fmt)
 
         profile = ["http://iiif.io/api/image/2/level2.json", {
-                "formats": [ "jpg", "png", "gif", "webp" ],
+                "formats": [ "jpg", "png", "gif", "webp", "tif" ],
                 "qualities": [ "default", "color", "gray", "bitonal" ],
                 "supports": [
                     "canonicalLinkHeader",
@@ -208,7 +208,7 @@ class InfoUnit(loris_t.LorisTest):
         info = img_info.ImageInfo(self.app, uri, fp, fmt)
 
         profile = ["http://iiif.io/api/image/2/level2.json", {
-                "formats": [ "jpg", "png", "gif", "webp" ],
+                "formats": [ "jpg", "png", "gif", "webp", "tif" ],
                 "qualities": [ "default", "gray", "bitonal" ],
                 "supports": [
                     "canonicalLinkHeader",
@@ -239,7 +239,7 @@ class InfoUnit(loris_t.LorisTest):
         info = img_info.ImageInfo(self.app, uri, fp, fmt)
 
         profile = ["http://iiif.io/api/image/2/level2.json", {
-                "formats": [ "jpg", "png", "gif", "webp" ],
+                "formats": [ "jpg", "png", "gif", "webp", "tif" ],
                 "qualities": [ "default", "color", "gray", "bitonal" ],
                 "supports": [
                     "canonicalLinkHeader",
@@ -353,7 +353,7 @@ class TestImageInfo(object):
     def test_profile_from_json_two_arg_profile(self):
         compliance_uri = 'http://iiif.io/api/image/2/level2.json'
         description = {
-            'formats': ['jpg', 'png', 'gif', 'webp'],
+            'formats': ['jpg', 'png', 'gif', 'webp', 'tif'],
             'qualities': ['default', 'bitonal', 'gray', 'color'],
             'supports': [
                 'canonicalLinkHeader',
@@ -427,7 +427,7 @@ class InfoFunctional(loris_t.LorisTest):
             f.write(resp.data)
 
         profile = ["http://iiif.io/api/image/2/level2.json", {
-                "formats": [ "jpg", "png", "gif", "webp" ],
+                "formats": [ "jpg", "png", "gif", "webp", "tif" ],
                 "qualities": [ "default", "bitonal", "gray", "color" ],
                 "supports": [
                     "canonicalLinkHeader",

--- a/tests/transforms_t.py
+++ b/tests/transforms_t.py
@@ -291,6 +291,12 @@ class Test_PILTransformer(loris_t.LorisTest,
         image = self.request_image_from_client(request_path)
         assert image.format == 'WEBP'
 
+    def test_can_request_tif_format(self):
+        ident = self.test_jpeg_id
+        request_path = '/%s/full/full/0/default.tif' % ident
+        image = self.request_image_from_client(request_path)
+        assert image.format == 'TIFF'
+
     def test_convert_to_bitonal_with_rotation_is_mode_LA(self):
         request_path = '/%s/full/full/45/bitonal.png' % self.ident
         image = self.request_image_from_client(request_path)


### PR DESCRIPTION
Enables output for uncompressed TIFFs. It turns out much of the handling bits are already there--"tif" is in the formats constant so the return content-type is already right as long as the Request objects know it's an allowed format. The base abstract transformer class just needed code to handle making TIFFs, the config needs to know it's an allowed format, and voila.

In principle output could also be compressed (AFAIK PIL understands LZW + JPEG compression as long as libtiff does, it's just a matter of requesting it in the call to `Image.save()` ) but I haven't really taken a close look to see where distros are at with their libtiff support. Anyway responding with a compressed TIFF is not super webby behavior?