### PR TITLE
Improve coverage and tests in resolver.py

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,3 +9,4 @@ exclude_lines =
     pragma: no cover
     assert False, "Should not be reachable"
     else:  # unreachable
+    .*:.* # Python \d.*

--- a/loris/identifiers.py
+++ b/loris/identifiers.py
@@ -7,6 +7,11 @@ import hashlib
 import os
 import re
 
+try:
+    from urllib.parse import quote_plus
+except ImportError:  # Python 2
+    from urllib import quote_plus
+
 
 class IdentRegexChecker(object):
     """
@@ -39,6 +44,12 @@ class CacheNamer(object):
         """
         Returns the name of the individual cache directory for this object.
         """
+        # This exists for back-compatibility reasons -- the MD5 hash works
+        # just as well on a quoted as unquoted string -- but an old version
+        # of this code quoted the string, and we want to preserve existing
+        # cache paths.
+        ident = quote_plus(ident)
+
         # Get the MD5 hash of the identifier, then we create the top-level
         # directory as 2 digits, and take pieces of 3 digits for each
         # subsequent directory.

--- a/loris/identifiers.py
+++ b/loris/identifiers.py
@@ -37,7 +37,7 @@ class CacheNamer(object):
     @staticmethod
     def ident_cache_name(ident):
         """
-        Returns the name of the cache directory for this object.
+        Returns the name of the individual cache directory for this object.
         """
         # Get the MD5 hash of the identifier, then we create the top-level
         # directory as 2 digits, and take pieces of 3 digits for each
@@ -49,3 +49,23 @@ class CacheNamer(object):
 
         dirnames = [ident_hash[0:2]] + [ident_hash[i:i+3] for i in range(2, len(ident_hash), 3)]
         return os.path.join(*tuple(dirnames))
+
+    @staticmethod
+    def cache_directory_name(ident):
+        """
+        Returns the name of the cache directory for this ident, relative
+        to the cache root.
+        """
+        # Split our potential PID spaces.  Fedora Commons is the most likely
+        # use case.
+        if not ident.startswith(('http://', 'https://')) and len(ident.split(':')) > 1:
+            cache_subroot = os.path.join(*tuple(ident.split(':')[:-1]))
+        elif ident.startswith(('http://', 'https://')):
+            cache_subroot = 'http'
+        else:
+            cache_subroot = ''
+
+        if cache_subroot:
+            return os.path.join(cache_subroot, CacheNamer.ident_cache_name(ident))
+        else:
+            return CacheNamer.ident_cache_name(ident)

--- a/loris/identifiers.py
+++ b/loris/identifiers.py
@@ -35,7 +35,7 @@ class CacheNamer(object):
     """
 
     @staticmethod
-    def cache_directory_name(ident):
+    def ident_cache_name(ident):
         """
         Returns the name of the cache directory for this object.
         """

--- a/loris/identifiers.py
+++ b/loris/identifiers.py
@@ -1,0 +1,27 @@
+# -*- encoding: utf-8
+"""
+Utilities for dealing with identifiers.
+"""
+
+import re
+
+
+class IdentRegexChecker(object):
+    """
+    Allows a user to specify a regex that matches all identifiers.
+
+    This can allow us to skip making a network/disk request if the identifier
+    is invalid -- we can return a 404 faster.
+
+    """
+    def __init__(self, ident_regex):
+        if ident_regex is not None:
+            self.ident_regex = re.compile(ident_regex)
+        else:
+            self.ident_regex = None
+
+    def is_allowed(self, ident):
+        if self.ident_regex is None:
+            return True
+        else:
+            return bool(self.ident_regex.match(ident))

--- a/loris/identifiers.py
+++ b/loris/identifiers.py
@@ -3,6 +3,8 @@
 Utilities for dealing with identifiers.
 """
 
+import hashlib
+import os
 import re
 
 
@@ -25,3 +27,25 @@ class IdentRegexChecker(object):
             return True
         else:
             return bool(self.ident_regex.match(ident))
+
+
+class CacheNamer(object):
+    """
+    Provides the name of objects stored in the cache based on their identifier.
+    """
+
+    @staticmethod
+    def cache_directory_name(ident):
+        """
+        Returns the name of the cache directory for this object.
+        """
+        # Get the MD5 hash of the identifier, then we create the top-level
+        # directory as 2 digits, and take pieces of 3 digits for each
+        # subsequent directory.
+        #
+        # For example, '12345678' becomes '12/345/678'.
+        #
+        ident_hash = hashlib.md5(ident.encode('utf8')).hexdigest()
+
+        dirnames = [ident_hash[0:2]] + [ident_hash[i:i+3] for i in range(2, len(ident_hash), 3)]
+        return os.path.join(*tuple(dirnames))

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -303,7 +303,7 @@ class SimpleHTTPResolver(_AbstractResolver):
     # Get the directory structure of the identifier itself
     @staticmethod
     def _ident_file_structure(ident):
-        return CacheNamer.cache_directory_name(ident)
+        return CacheNamer.ident_cache_name(ident)
 
     def cache_dir_path(self, ident):
         ident = unquote(ident)

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -12,15 +12,14 @@ from os import remove
 from shutil import copy
 import tempfile
 from contextlib import closing
-import hashlib
 import glob
 import json
 import os
 
 try:
-    from urllib.parse import quote_plus, unquote
+    from urllib.parse import unquote
 except ImportError:  # Python 2
-    from urllib import quote_plus, unquote
+    from urllib import unquote
 
 import requests
 

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -15,6 +15,7 @@ from contextlib import closing
 import hashlib
 import glob
 import json
+import os
 
 try:
     from urllib.parse import quote_plus, unquote
@@ -243,7 +244,7 @@ class SimpleHTTPResolver(_AbstractResolver):
         if not self._ident_regex_checker.is_allowed(ident):
             return False
 
-        fp = join(self.cache_root, SimpleHTTPResolver._cache_subroot(ident))
+        fp = self.cache_dir_path(ident=ident)
         if exists(fp):
             return True
         else:
@@ -284,32 +285,10 @@ class SimpleHTTPResolver(_AbstractResolver):
             )
         return (url, self.request_options())
 
-    # Get a subdirectory structure for the cache_subroot through hashing.
-    @staticmethod
-    def _cache_subroot(ident):
-        cache_subroot = ''
-
-        # Split out potential pidspaces... Fedora Commons most likely use case.
-        if ident[0:6] != 'http:/' and ident[0:7] != 'https:/' and len(ident.split(':')) > 1:
-            for split_ident in ident.split(':')[0:-1]:
-                cache_subroot = join(cache_subroot, split_ident)
-        elif ident[0:6] == 'http:/' or ident[0:7] == 'https:/':
-            cache_subroot = 'http'
-
-        cache_subroot = join(cache_subroot, SimpleHTTPResolver._ident_file_structure(ident))
-
-        return cache_subroot
-
-    # Get the directory structure of the identifier itself
-    @staticmethod
-    def _ident_file_structure(ident):
-        return CacheNamer.ident_cache_name(ident)
-
     def cache_dir_path(self, ident):
-        ident = unquote(ident)
-        return join(
-                self.cache_root,
-                SimpleHTTPResolver._cache_subroot(ident)
+        return os.path.join(
+            self.cache_root,
+            CacheNamer.cache_directory_name(ident=ident)
         )
 
     def raise_404_for_ident(self, ident):

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -24,7 +24,7 @@ except ImportError:  # Python 2
 import requests
 
 from loris import constants
-from loris.identifiers import IdentRegexChecker
+from loris.identifiers import CacheNamer, IdentRegexChecker
 from loris.loris_exception import ResolverException
 from loris.utils import mkdir_p, safe_rename
 from loris.img_info import ImageInfo
@@ -212,6 +212,7 @@ class SimpleHTTPResolver(_AbstractResolver):
         self._ident_regex_checker = IdentRegexChecker(
             ident_regex=self.config.get('ident_regex')
         )
+        self._cache_namer = CacheNamer()
 
         if 'cache_root' in self.config:
             self.cache_root = self.config['cache_root']
@@ -302,15 +303,7 @@ class SimpleHTTPResolver(_AbstractResolver):
     # Get the directory structure of the identifier itself
     @staticmethod
     def _ident_file_structure(ident):
-        file_structure = ''
-        ident_hash = hashlib.md5(quote_plus(ident).encode('utf8')).hexdigest()
-        # First level 2 digit directory then do three digits...
-        file_structure_list = [ident_hash[0:2]] + [ident_hash[i:i+3] for i in range(2, len(ident_hash), 3)]
-
-        for piece in file_structure_list:
-            file_structure = join(file_structure, piece)
-
-        return file_structure
+        return CacheNamer.cache_directory_name(ident)
 
     def cache_dir_path(self, ident):
         ident = unquote(ident)

--- a/tests/identifiers_t.py
+++ b/tests/identifiers_t.py
@@ -1,0 +1,27 @@
+# -*- encoding: utf-8
+
+from hypothesis import given
+from hypothesis.strategies import text
+import pytest
+
+from loris.identifiers import IdentRegexChecker
+
+
+class TestIdentRegexChecker(object):
+
+    @given(text(min_size=1))
+    def test_any_ident_is_allowed_if_regex_is_none(self, ident):
+        checker = IdentRegexChecker(ident_regex=None)
+        assert checker.is_allowed(ident=ident) is True
+
+    @pytest.mark.parametrize('ident_regex, ident, expected_is_allowed', [
+        (r'^A+$', 'AAAA', True),
+        (r'^A+$', 'AAAB', False),
+        (r'[0-9]+\.jpg', '001.jpg', True),
+        (r'[0-9]+\.jpg', '001.tif', False),
+    ])
+    def test_checker_has_correct_is_allowed(
+        self, ident_regex, ident, expected_is_allowed
+    ):
+        checker = IdentRegexChecker(ident_regex=ident_regex)
+        assert checker.is_allowed(ident=ident) is expected_is_allowed

--- a/tests/identifiers_t.py
+++ b/tests/identifiers_t.py
@@ -4,7 +4,7 @@ from hypothesis import given
 from hypothesis.strategies import text
 import pytest
 
-from loris.identifiers import IdentRegexChecker
+from loris.identifiers import CacheNamer, IdentRegexChecker
 
 
 class TestIdentRegexChecker(object):
@@ -25,3 +25,16 @@ class TestIdentRegexChecker(object):
     ):
         checker = IdentRegexChecker(ident_regex=ident_regex)
         assert checker.is_allowed(ident=ident) is expected_is_allowed
+
+
+class TestCacheNamer(object):
+
+    cache_namer = CacheNamer()
+
+    @pytest.mark.parametrize('ident, expected_directory', [
+        ('0001.jpg', '71/d50/39c/f12/091/40b/910/5a4/696/b0b/155'),
+        ('example.png', '89/51d/ba4/39b/1aa/07c/688/6dc/bc3/87a/b32'),
+    ])
+    def test_cache_directory_name(self, ident, expected_directory):
+        actual_directory = self.cache_namer.cache_directory_name(ident=ident)
+        assert actual_directory == expected_directory

--- a/tests/identifiers_t.py
+++ b/tests/identifiers_t.py
@@ -35,6 +35,6 @@ class TestCacheNamer(object):
         ('0001.jpg', '71/d50/39c/f12/091/40b/910/5a4/696/b0b/155'),
         ('example.png', '89/51d/ba4/39b/1aa/07c/688/6dc/bc3/87a/b32'),
     ])
-    def test_cache_directory_name(self, ident, expected_directory):
-        actual_directory = self.cache_namer.cache_directory_name(ident=ident)
+    def test_ident_cache_name(self, ident, expected_directory):
+        actual_directory = self.cache_namer.ident_cache_name(ident=ident)
         assert actual_directory == expected_directory

--- a/tests/resolver_t.py
+++ b/tests/resolver_t.py
@@ -294,10 +294,19 @@ class Test_SimpleHTTPResolver(loris_t.LorisTest):
         #Test with a full uri
         #Note: This seems weird but idents resolve wrong and removes a slash from //
         ident = quote_plus('http://sample.sample/0001')
-        expected_path = os.path.join(
-            self.app.resolver.cache_root, 'http',
-            'aa/003/aa5/c26/7b8/633/39a/d76/cd0/30d/c3c', 'loris_cache.tif'
-        )
+        expected_path = join(self.app.resolver.cache_root, 'http')
+        expected_path = join(expected_path, '32')
+        expected_path = join(expected_path, '3a5')
+        expected_path = join(expected_path, '353')
+        expected_path = join(expected_path, '8f5')
+        expected_path = join(expected_path, '0de')
+        expected_path = join(expected_path, '1d3')
+        expected_path = join(expected_path, '011')
+        expected_path = join(expected_path, '675')
+        expected_path = join(expected_path, 'ebc')
+        expected_path = join(expected_path, 'c75')
+        expected_path = join(expected_path, '083')
+        expected_path = join(expected_path, 'loris_cache.tif')
 
         self.assertFalse(exists(expected_path))
         ii = self.app.resolver.resolve(self.app, ident, "")

--- a/tests/resolver_t.py
+++ b/tests/resolver_t.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import
 
 import copy
-import os
 from os.path import dirname
 from os.path import isfile
 from os.path import join

--- a/tests/resolver_t.py
+++ b/tests/resolver_t.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import
 
 import copy
+import os
 from os.path import dirname
 from os.path import isfile
 from os.path import join
@@ -293,19 +294,10 @@ class Test_SimpleHTTPResolver(loris_t.LorisTest):
         #Test with a full uri
         #Note: This seems weird but idents resolve wrong and removes a slash from //
         ident = quote_plus('http://sample.sample/0001')
-        expected_path = join(self.app.resolver.cache_root, 'http')
-        expected_path = join(expected_path, '32')
-        expected_path = join(expected_path, '3a5')
-        expected_path = join(expected_path, '353')
-        expected_path = join(expected_path, '8f5')
-        expected_path = join(expected_path, '0de')
-        expected_path = join(expected_path, '1d3')
-        expected_path = join(expected_path, '011')
-        expected_path = join(expected_path, '675')
-        expected_path = join(expected_path, 'ebc')
-        expected_path = join(expected_path, 'c75')
-        expected_path = join(expected_path, '083')
-        expected_path = join(expected_path, 'loris_cache.tif')
+        expected_path = os.path.join(
+            self.app.resolver.cache_root, 'http',
+            'aa/003/aa5/c26/7b8/633/39a/d76/cd0/30d/c3c', 'loris_cache.tif'
+        )
 
         self.assertFalse(exists(expected_path))
         ii = self.app.resolver.resolve(self.app, ident, "")

--- a/tests/resolver_t.py
+++ b/tests/resolver_t.py
@@ -340,6 +340,23 @@ class Test_SimpleHTTPResolver(loris_t.LorisTest):
         self.assertEqual(ii.src_format, 'tif')
         self.assertTrue(isfile(ii.src_img_fp))
 
+    @responses.activate
+    def test_is_resolvable_uses_cached_result(self):
+        self._mock_urls()
+
+        config = {
+            'cache_root' : self.SRC_IMAGE_CACHE,
+            'source_prefix' : 'http://sample.sample/',
+            'source_suffix' : '',
+            'default_format' : 'tif',
+            'head_resolvable' : True,
+            'uri_resolvable' : True
+        }
+        self.app.resolver = SimpleHTTPResolver(config)
+
+        assert self.app.resolver.resolve(self.app, ident='0001', base_uri='')
+        assert self.app.resolver.is_resolvable(ident='0001')
+
 
 class TestSimpleHTTPResolver(object):
 

--- a/tests/resolver_t.py
+++ b/tests/resolver_t.py
@@ -391,6 +391,21 @@ class TestSimpleHTTPResolver(object):
         resolver = SimpleHTTPResolver(config=config)
         assert not resolver.is_resolvable(ident='example.png')
 
+    @responses.activate
+    @pytest.mark.parametrize('ident_regex, ident, expected_resolvable', [
+        ('A+', 'bbb.jpg', False),
+        ('\d+', '0001', True),
+        ('\d+Z', '0001', False),
+    ])
+    def test_ident_regex_blocks_based_on_ident(self, mock_responses, ident_regex, ident, expected_resolvable):
+        config = {
+            'cache_root': '/var/cache/loris',
+            'source_prefix': 'http://sample.sample/',
+            'ident_regex': ident_regex,
+        }
+        resolver = SimpleHTTPResolver(config=config)
+        assert resolver.is_resolvable(ident=ident) == expected_resolvable
+
 
 class Test_TemplateHTTPResolver(object):
 


### PR DESCRIPTION
This started as a small patch, and grew a bit:

* The ident regex code is untested. While adding tests, I realised it can be a standalone piece – so I moved it out into its own class. The new class features a complete set of tests, and caches the regex, so there should be a (minor) performance improvement.

* In the same vein, I moved out the code which constructs cache directory names. I also nixed a pointless unquote-quote cycle, which would at best have cancelled each other out.

* I added a new SimpleHTTPResolver tests which checks if something is resolvable *after* it's been saved to the cache – previously this scenario was untested.