### PR TITLE
Allow decimal percentage values for size parameter

### DIFF
--- a/loris/parameters.py
+++ b/loris/parameters.py
@@ -262,7 +262,7 @@ class SizeParameter(object):
         h (int):
             The height.
     '''
-    PCT_MODE_REGEX = re.compile(r'^pct:(?P<percentage>[0-9]+)$')
+    PCT_MODE_REGEX = re.compile(r'^pct:(?P<percentage>[0-9]+(\.[0-9]+)?)$')
     PIXEL_MODE_REGEX = re.compile(
         r'^(?P<best_fit>!?)(?P<width>[0-9]*),(?P<height>[0-9]*)$'
     )

--- a/tests/parameters_t.py
+++ b/tests/parameters_t.py
@@ -224,6 +224,12 @@ class TestSizeParameter(_ParameterTest):
         sp = SizeParameter('pct:50', rp)
         self.assertEquals(sp.w, 1)
 
+    def test_decimal_percentage_is_allowed(self):
+        info = build_image_info(width=400, height=200)
+        rp = RegionParameter('full', info)
+        sp = SizeParameter('pct:6.25', rp)
+        self.assertEquals(sp.w, 25)
+
     def test_negative_x_percentage_is_rejected(self):
         info = build_image_info()
         with self.assertRaises(RequestException):


### PR DESCRIPTION
Loris currently answers with an error (e.g. "Size syntax u'pct:12.5' is not valid.") if the percentage value for the size parameter isn't an integer. But floating point numbers are allowed by the API, and they would work perfectly if only the regex would match them...