### PR TITLE
Create the specified temporary directory when Loris starts

### DIFF
--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -41,7 +41,7 @@ from loris.loris_exception import (
     SyntaxException,
     TransformException,
 )
-
+from loris.utils import mkdir_p
 
 
 getcontext().prec = 25 # Decimal precision. This should be plenty.
@@ -328,6 +328,12 @@ class Loris(object):
         # make the loris.Loris configs attrs for easier access
         _loris_config = self.app_configs['loris.Loris']
         self.tmp_dp = _loris_config['tmp_dp']
+
+        try:
+            mkdir_p(self.tmp_dp)
+        except Exception as exc:
+            raise ConfigError("Error creating tmp_dp %s: %r" % (self.tmp_dp, exc))
+
         self.www_dp = _loris_config['www_dp']
         self.enable_caching = _loris_config['enable_caching']
         self.redirect_canonical_image_request = _loris_config['redirect_canonical_image_request']

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -581,3 +581,20 @@ class TestInfoCache(loris_t.LorisTest):
 
         with pytest.raises(KeyError):
             cache[req]
+
+    def test_creates_cache_dir(self):
+        root = os.path.join(tempfile.mkdtemp(), "doesnotexist")
+        assert not os.path.exists(root)
+        cache = img_info.InfoCache(root=root)
+        path = self.test_jpeg_fp
+        req = webapp_t._get_werkzeug_request(path=path)
+
+        info = img_info.ImageInfo(
+            app=self.app,
+            ident=self.test_jpeg_uri,
+            src_img_fp=self.test_jpeg_fp,
+            src_format=self.test_jpeg_fmt
+        )
+
+        cache[req] = info
+        assert cache[req][0] == info

--- a/tests/webapp_t.py
+++ b/tests/webapp_t.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import
 
 from datetime import datetime
-import os
 from os import path, listdir
 from time import sleep
 from unittest import TestCase

--- a/tests/webapp_t.py
+++ b/tests/webapp_t.py
@@ -20,7 +20,7 @@ from loris import img_info, webapp
 from loris.authorizer import NullAuthorizer
 from loris.loris_exception import ConfigError
 from loris.transforms import KakaduJP2Transformer, OPJ_JP2Transformer
-from loris.webapp import get_debug_config
+from loris.webapp import get_debug_config, Loris
 from tests import loris_t
 
 
@@ -595,6 +595,12 @@ class WebappIntegration(loris_t.LorisTest):
         assert self.app.tmp_dp == "/tmp/doesnotexist"
 
         self.client.get("/%s/full/full/0/default.jpg" % self.test_jpeg_id)
+
+    def test_invalid_tmp_dir_is_configerror(self):
+        config = get_debug_config('kdu')
+        config["loris.Loris"]["tmp_dp"] = "/dev/null/tmp"
+        with pytest.raises(ConfigError, match="Error creating tmp_dp /dev/null/tmp:"):
+            Loris(config)
 
     def _assert_tmp_has_no_files(self):
         # callback should delete the image before the test ends, so the tmp dir

--- a/tests/webapp_t.py
+++ b/tests/webapp_t.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 
 from datetime import datetime
+import os
 from os import path, listdir
 from time import sleep
 from unittest import TestCase
@@ -19,6 +20,7 @@ from loris import img_info, webapp
 from loris.authorizer import NullAuthorizer
 from loris.loris_exception import ConfigError
 from loris.transforms import KakaduJP2Transformer, OPJ_JP2Transformer
+from loris.webapp import get_debug_config
 from tests import loris_t
 
 
@@ -584,6 +586,15 @@ class WebappIntegration(loris_t.LorisTest):
         with self.client.get(to_get):
             pass
         self._assert_tmp_has_no_files()
+
+    def test_can_use_tmp_dir_for_transforms(self):
+        config = get_debug_config('kdu')
+        config["loris.Loris"]["tmp_dp"] = "/tmp/doesnotexist"
+        self.build_client_from_config(config)
+
+        assert self.app.tmp_dp == "/tmp/doesnotexist"
+
+        self.client.get("/%s/full/full/0/default.jpg" % self.test_jpeg_id)
 
     def _assert_tmp_has_no_files(self):
         # callback should delete the image before the test ends, so the tmp dir


### PR DESCRIPTION
Some tests and a patch for #446. I added a test for the InfoCache because that's the other place where we might be making this mistake (although it seems fine).

Closes #446.