### PR TITLE
Set the Content-Disposition header in image responses

### DIFF
--- a/tests/webapp_t.py
+++ b/tests/webapp_t.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import json
+import os.path
 from os import path, listdir
 from time import sleep
 from unittest import TestCase
@@ -114,6 +115,29 @@ class TestLoris(loris_t.LorisTest):
 
         resp = client.get("/%s/full/full/0/default.jpg" % self.test_jpeg_id)
         assert resp.status_code == 200
+
+    def test_sends_content_disposition_header_for_image(self):
+        config = webapp.get_debug_config("kdu")
+        app = webapp.Loris(config)
+
+        client = Client(
+            application=webapp.Loris(config),
+            response_wrapper=BaseResponse
+        )
+
+        jpg_resp = client.get("/%s/full/full/0/default.jpg" % self.test_jpeg_id)
+
+        expected_filename = os.path.relpath(self.test_jpeg_fp, self.test_img_dir)
+
+        assert jpg_resp.headers["Content-Disposition"] == (
+            "filename*=utf-8''%s" % expected_filename
+        )
+
+        png_resp = client.get("/%s/full/full/0/default.png" % self.test_jpeg_id)
+
+        assert png_resp.headers["Content-Disposition"] == (
+            "filename*=utf-8''%s.png" % expected_filename
+        )
 
 
 class TestLorisRequest(TestCase):


### PR DESCRIPTION
Currently browsers will use the last part of the path as a filename, which is almost always something unhelpful like "default.jpg" or "default.png".  This patch changes Loris to start sending a header which tells browsers to include the ident in the responses.

This should make it easier for people to trace images back to the original from a downloaded file.

A first step towards https://github.com/loris-imageserver/loris/issues/18