### PR TITLE
ImageInfo - remove "ident"

### DIFF
--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -56,12 +56,12 @@ class EnhancedJSONEncoder(json.JSONEncoder):
         return obj
 
 
-class ImageInfo(JP2Extractor, object):
+class ImageInfo(JP2Extractor):
     '''Info about the image.
     See: <http://iiif.io/api/image/>
 
     Slots:
-        ident (str): The image identifier.
+        base_uri (str): The base URI of the image, including scheme, server, prefix and identifier without a trailing slash..
         width (int)
         height (int)
         scaleFactors [(int)]
@@ -79,14 +79,14 @@ class ImageInfo(JP2Extractor, object):
 
     '''
     __slots__ = ('scaleFactors', 'width', 'tiles', 'height',
-        'ident', 'profile', 'protocol', 'sizes', 'service',
+        'base_uri', 'profile', 'protocol', 'sizes', 'service',
         'attribution', 'logo', 'license', 'auth_rules',
         'src_format', 'src_img_fp', 'color_profile_bytes')
 
-    def __init__(self, app=None, ident="", src_img_fp="", src_format="", extra={}):
+    def __init__(self, app=None, base_uri="", src_img_fp="", src_format="", extra={}):
 
         self.protocol = PROTOCOL
-        self.ident = ident
+        self.base_uri = base_uri
         self.src_img_fp = src_img_fp
         self.src_format = src_format
         self.attribution = None
@@ -144,13 +144,13 @@ class ImageInfo(JP2Extractor, object):
         new_inst = ImageInfo()
         j = json.loads(json_string)
 
-        new_inst.ident = j.get(u'@id')
-        new_inst.width = j.get(u'width')
-        new_inst.height = j.get(u'height')
+        new_inst.base_uri = j.get('@id')
+        new_inst.width = j.get('width')
+        new_inst.height = j.get('height')
         # TODO: make sure these are resulting in error or Nones when
         # we load from the filesystem
-        new_inst.tiles = j.get(u'tiles')
-        new_inst.sizes = j.get(u'sizes')
+        new_inst.tiles = j.get('tiles')
+        new_inst.sizes = j.get('sizes')
 
         profile_args = tuple(j.get(u'profile', []))
         new_inst.profile = Profile(*profile_args)
@@ -236,7 +236,7 @@ class ImageInfo(JP2Extractor, object):
         """returns only IIIF info (not Loris-specific info like src_format)"""
         d = {}
         d['@context'] = CONTEXT
-        d['@id'] = self.ident
+        d['@id'] = self.base_uri
         d['protocol'] = self.protocol
         d['profile'] = self.profile
         d['width'] = self.width

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -61,13 +61,11 @@ class ImageInfo(JP2Extractor):
     See: <http://iiif.io/api/image/>
 
     Slots:
-        base_uri (str): The base URI of the image, including scheme, server, prefix and identifier without a trailing slash..
         width (int)
         height (int)
         scaleFactors [(int)]
         sizes [(str)]: the optimal sizes of the image to request
         tiles: [{}]
-        protocol (str): the protocol URI (constant)
         service (dict): services associated with the image
         profile (Profile): Features supported by the server/available for
             this image
@@ -79,14 +77,11 @@ class ImageInfo(JP2Extractor):
 
     '''
     __slots__ = ('scaleFactors', 'width', 'tiles', 'height',
-        'base_uri', 'profile', 'protocol', 'sizes', 'service',
+        'profile', 'sizes', 'service',
         'attribution', 'logo', 'license', 'auth_rules',
         'src_format', 'src_img_fp', 'color_profile_bytes')
 
-    def __init__(self, app=None, base_uri="", src_img_fp="", src_format="", extra={}):
-
-        self.protocol = PROTOCOL
-        self.base_uri = base_uri
+    def __init__(self, app=None, src_img_fp="", src_format="", extra={}):
         self.src_img_fp = src_img_fp
         self.src_format = src_format
         self.attribution = None
@@ -144,7 +139,6 @@ class ImageInfo(JP2Extractor):
         new_inst = ImageInfo()
         j = json.loads(json_string)
 
-        new_inst.base_uri = j.get('@id')
         new_inst.width = j.get('width')
         new_inst.height = j.get('height')
         # TODO: make sure these are resulting in error or Nones when
@@ -233,11 +227,8 @@ class ImageInfo(JP2Extractor):
         return int(ceil(dim_len * 1.0/scale))
 
     def _get_iiif_info(self):
-        """returns only IIIF info (not Loris-specific info like src_format)"""
         d = {}
         d['@context'] = CONTEXT
-        d['@id'] = self.base_uri
-        d['protocol'] = self.protocol
         d['profile'] = self.profile
         d['width'] = self.width
         d['height'] = self.height
@@ -252,11 +243,13 @@ class ImageInfo(JP2Extractor):
             d['logo'] = self.logo
         if self.license:
             d['license'] = self.license
-
         return d
 
-    def to_iiif_json(self):
+    def to_iiif_json(self, base_uri):
+        """returns only IIIF info (not Loris-specific info like src_format)"""
         d = self._get_iiif_info()
+        d['@id'] = base_uri
+        d['protocol'] = PROTOCOL
         return json.dumps(d, cls=EnhancedJSONEncoder)
 
     def to_full_info_json(self):

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -89,9 +89,6 @@ class _AbstractResolver(object):
         else:
             return {}
 
-    def fix_base_uri(self, base_uri):
-        return base_uri
-
     def format_from_ident(self, ident):
         if ident.rfind('.') != -1:
             extension = ident.split('.')[-1]
@@ -139,7 +136,6 @@ class SimpleFSResolver(_AbstractResolver):
 
         source_fp = self.source_file_path(ident)
         format_ = self.format_from_ident(ident)
-        uri = self.fix_base_uri(base_uri)
         extra = self.get_extra_info(ident, source_fp)
         return ImageInfo(app, source_fp, format_, extra)
 
@@ -373,7 +369,6 @@ class SimpleHTTPResolver(_AbstractResolver):
         if not cached_file_path:
             cached_file_path = self.copy_to_cache(ident)
         format_ = self.get_format(cached_file_path, None)
-        uri = self.fix_base_uri(base_uri)
         if self.use_extra_info:
             extra = self.get_extra_info(ident, cached_file_path)
         else:
@@ -559,6 +554,5 @@ class SourceImageCachingResolver(_AbstractResolver):
 
         cache_fp = self.cache_file_path(ident)
         format_ = self.format_from_ident(ident)
-        uri = self.fix_base_uri(base_uri)
         extra = self.get_extra_info(ident, cache_fp)
         return ImageInfo(app, cache_fp, format_, extra)

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -141,7 +141,7 @@ class SimpleFSResolver(_AbstractResolver):
         format_ = self.format_from_ident(ident)
         uri = self.fix_base_uri(base_uri)
         extra = self.get_extra_info(ident, source_fp)
-        return ImageInfo(app, uri, source_fp, format_, extra)
+        return ImageInfo(app, source_fp, format_, extra)
 
 
 class ExtensionNormalizingFSResolver(SimpleFSResolver):
@@ -378,7 +378,7 @@ class SimpleHTTPResolver(_AbstractResolver):
             extra = self.get_extra_info(ident, cached_file_path)
         else:
             extra = {}
-        return ImageInfo(app, uri, cached_file_path, format_, extra)
+        return ImageInfo(app, cached_file_path, format_, extra)
 
 
 class TemplateHTTPResolver(SimpleHTTPResolver):
@@ -561,4 +561,4 @@ class SourceImageCachingResolver(_AbstractResolver):
         format_ = self.format_from_ident(ident)
         uri = self.fix_base_uri(base_uri)
         extra = self.get_extra_info(ident, cache_fp)
-        return ImageInfo(app, uri, cache_fp, format_, extra)
+        return ImageInfo(app, cache_fp, format_, extra)

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -537,7 +537,7 @@ class Loris(object):
             callback = request.args.get('callback', None)
             if callback:
                 r.mimetype = 'application/javascript'
-                r.data = '%s(%s);' % (callback, info.to_iiif_json())
+                r.data = '%s(%s);' % (callback, info.to_iiif_json(base_uri))
             else:
                 if request.headers.get('accept') == 'application/ld+json':
                     r.content_type = 'application/ld+json'
@@ -545,7 +545,7 @@ class Loris(object):
                     r.content_type = 'application/json'
                     l = '<http://iiif.io/api/image/2/context.json>;rel="http://www.w3.org/ns/json-ld#context";type="application/ld+json"'
                     r.headers['Link'] = '%s,%s' % (r.headers['Link'], l)
-                r.data = info.to_iiif_json()
+                r.data = info.to_iiif_json(base_uri)
         return r
 
     def _get_info(self,ident,request,base_uri):

--- a/tests/authorizer_t.py
+++ b/tests/authorizer_t.py
@@ -220,7 +220,7 @@ class Test_RulesAuthorizer(unittest.TestCase):
         # Set a degraded tier
         # Should redirect for empty, pass for cookie/token
         self.badInfo.auth_rules = {"allowed": ["test"], "tiers":
-            [{"identifier":"http://localhost:5004/"+self.okayInfo.ident}]}
+            [{"identifier":"http://localhost:5004/"+self.okayInfo.base_uri}]}
         authd = self.authorizer.is_authorized(self.badInfo, self.emptyRequest)
         self.assertEqual(authd['status'], "redirect")
         authd = self.authorizer.is_authorized(self.badInfo, self.tokenRequest)
@@ -264,7 +264,7 @@ class Test_RulesAuthorizer(unittest.TestCase):
         # Set a degraded tier
         # Should redirect for empty, pass for cookie/token
         self.badInfo.auth_rules = {"allowed": ["test"], "tiers":
-            [{"identifier":"http://localhost:5004/"+self.okayInfo.ident}]}
+            [{"identifier":"http://localhost:5004/"+self.okayInfo.base_uri}]}
         authd = self.authorizer.is_authorized(self.badInfo, self.emptyRequest)
         self.assertEqual(authd['status'], "redirect")
         authd = self.authorizer.is_authorized(self.badInfo, self.jwtTokenRequest)

--- a/tests/authorizer_t.py
+++ b/tests/authorizer_t.py
@@ -45,7 +45,6 @@ class Test_AbstractAuthorizer(unittest.TestCase):
 class Test_NullAuthorizer(unittest.TestCase):
 
     def setUp(self):
-        ident = "test"
         fp = "img/test.png"
         fmt = "png"
         self.authorizer = NullAuthorizer({})
@@ -67,7 +66,6 @@ class Test_NullAuthorizer(unittest.TestCase):
 class Test_NooneAuthorizer(unittest.TestCase):
 
     def setUp(self):
-        ident = "test"
         fp = "img/test.png"
         fmt = "png"
         self.authorizer = NooneAuthorizer({})
@@ -89,7 +87,6 @@ class Test_NooneAuthorizer(unittest.TestCase):
 class Test_SingleDegradingAuthorizer(unittest.TestCase):
 
     def setUp(self):
-        ident = "test"
         fp = "img/test.png"
         fmt = "png"
         self.authorizer = SingleDegradingAuthorizer({})
@@ -116,7 +113,6 @@ class Test_SingleDegradingAuthorizer(unittest.TestCase):
 class Test_RulesAuthorizer(unittest.TestCase):
 
     def setUp(self):
-        ident = "test"
         fp = "img/test.png"
         fmt = "png"
 

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -9,7 +9,6 @@ import pytest
 from werkzeug.datastructures import Headers
 
 from loris import img_info, loris_exception
-from loris.constants import PROTOCOL
 from loris.img_info import ImageInfo, Profile
 from loris.loris_exception import ImageInfoException
 from tests import loris_t, webapp_t
@@ -25,11 +24,6 @@ class MockApp:
 
 
 class InfoUnit(loris_t.LorisTest):
-    'Tests ImageInfo constructors.'
-
-    #def setUp(self):
-    #    super(InfoUnit, self).setUp()
-    #    self.mockapp = MockApp()
 
     def test_color_jp2_info_from_image(self):
         fp = self.test_jp2_color_fp
@@ -57,7 +51,7 @@ class InfoUnit(loris_t.LorisTest):
 
         #test that sizeAboveFull isn't in profile if max_size_above_full is > 0 and <= 100
         self.app.max_size_above_full = 80
-        info = img_info.ImageInfo(self.app, uri, fp, fmt)
+        info = img_info.ImageInfo(self.app, fp, fmt)
 
         self.assertEqual(info.width, self.test_jp2_color_dims[0])
         self.assertEqual(info.height, self.test_jp2_color_dims[1])
@@ -65,11 +59,9 @@ class InfoUnit(loris_t.LorisTest):
         self.assertEqual(info.profile.description, profile[1])
         self.assertEqual(info.tiles, self.test_jp2_color_tiles)
         self.assertEqual(info.sizes, self.test_jp2_color_sizes)
-        self.assertEqual(info.base_uri, uri)
-        self.assertEqual(info.protocol, PROTOCOL)
 
         self.app.max_size_above_full = 0
-        info = img_info.ImageInfo(self.app, uri, fp, fmt)
+        info = img_info.ImageInfo(self.app, fp, fmt)
         self.assertTrue('sizeAboveFull' in info.profile.description['supports'])
         self.app.max_size_above_full = 200
 
@@ -80,7 +72,7 @@ class InfoUnit(loris_t.LorisTest):
         ident = self.test_jp2_with_precincts_id
         uri = self.test_jp2_with_precincts_uri
 
-        info = img_info.ImageInfo(self.app, uri, fp, fmt)
+        info = img_info.ImageInfo(self.app, fp, fmt)
 
         self.assertEqual(info.tiles, self.test_jp2_with_precincts_tiles)
         self.assertEqual(info.sizes, self.test_jp2_with_precincts_sizes)
@@ -92,7 +84,7 @@ class InfoUnit(loris_t.LorisTest):
         uri = self.test_jp2_with_embedded_profile_uri
         profile_copy_fp = self.test_jp2_embedded_profile_copy_fp
 
-        info = img_info.ImageInfo(self.app, uri, fp, fmt)
+        info = img_info.ImageInfo(self.app, fp, fmt)
 
         with open(self.test_jp2_embedded_profile_copy_fp, 'rb') as fixture_bytes:
             self.assertEqual(info.color_profile_bytes, fixture_bytes.read())
@@ -103,7 +95,7 @@ class InfoUnit(loris_t.LorisTest):
         ident = self.test_jp2_color_id
         uri = self.test_jp2_color_uri
 
-        info = img_info.ImageInfo(self.app, uri, fp, fmt)
+        info = img_info.ImageInfo(self.app, fp, fmt)
         self.assertEqual(info.color_profile_bytes, None)
 
     def test_gray_jp2_info_from_image(self):
@@ -130,7 +122,7 @@ class InfoUnit(loris_t.LorisTest):
             }
         ]
 
-        info = img_info.ImageInfo(self.app, uri, fp, fmt)
+        info = img_info.ImageInfo(self.app, fp, fmt)
 
         self.assertEqual(info.width, self.test_jp2_gray_dims[0])
         self.assertEqual(info.height, self.test_jp2_gray_dims[1])
@@ -138,8 +130,6 @@ class InfoUnit(loris_t.LorisTest):
         self.assertEqual(info.profile.description, profile[1])
         self.assertEqual(info.tiles, self.test_jp2_gray_tiles)
         self.assertEqual(info.sizes, self.test_jp2_gray_sizes)
-        self.assertEqual(info.base_uri, uri)
-        self.assertEqual(info.protocol, PROTOCOL)
 
     def test_info_from_jpg_marked_as_jp2(self):
         fp = path.join(self.test_img_dir, '01', '03', '0001.jpg')
@@ -147,7 +137,7 @@ class InfoUnit(loris_t.LorisTest):
         ident = '01%2f03%2f0001.jpg'
         uri = '%s/%s' % (self.URI_BASE, ident)
         with self.assertRaises(loris_exception.ImageInfoException) as cm:
-            img_info.ImageInfo(self.app, uri, fp, fmt)
+            img_info.ImageInfo(self.app, fp, fmt)
         self.assertEqual(str(cm.exception), 'Invalid JP2 file')
 
     def test_info_from_invalid_src_format(self):
@@ -157,7 +147,7 @@ class InfoUnit(loris_t.LorisTest):
         uri = '%s/%s' % (self.URI_BASE, ident)
         error_message = "Didn\'t get a source format, or at least one we recognize ('invalid_format')."
         with self.assertRaises(loris_exception.ImageInfoException) as cm:
-            img_info.ImageInfo(self.app, uri, fp, fmt)
+            img_info.ImageInfo(self.app, fp, fmt)
         self.assertEqual(str(cm.exception), error_message)
 
     def test_jpeg_info_from_image(self):
@@ -166,7 +156,7 @@ class InfoUnit(loris_t.LorisTest):
         ident = self.test_jpeg_id
         uri = self.test_jpeg_uri
 
-        info = img_info.ImageInfo(self.app, uri, fp, fmt)
+        info = img_info.ImageInfo(self.app, fp, fmt)
 
         profile = ["http://iiif.io/api/image/2/level2.json", {
                 "formats": [ "jpg", "png", "gif", "webp", "tif" ],
@@ -187,8 +177,6 @@ class InfoUnit(loris_t.LorisTest):
         self.assertEqual(info.profile.compliance_uri, profile[0])
         self.assertEqual(info.profile.description, profile[1])
         self.assertEqual(info.sizes, self.test_jpeg_sizes)
-        self.assertEqual(info.base_uri, uri)
-        self.assertEqual(info.protocol, PROTOCOL)
 
     def test_png_info_from_image(self):
         fp = self.test_png_fp
@@ -196,7 +184,7 @@ class InfoUnit(loris_t.LorisTest):
         ident = self.test_png_id
         uri = self.test_png_uri
 
-        info = img_info.ImageInfo(self.app, uri, fp, fmt)
+        info = img_info.ImageInfo(self.app, fp, fmt)
 
         profile = ["http://iiif.io/api/image/2/level2.json", {
                 "formats": [ "jpg", "png", "gif", "webp", "tif" ],
@@ -217,8 +205,6 @@ class InfoUnit(loris_t.LorisTest):
         self.assertEqual(info.profile.compliance_uri, profile[0])
         self.assertEqual(info.profile.description, profile[1])
         self.assertEqual(info.sizes, self.test_png_sizes)
-        self.assertEqual(info.base_uri, uri)
-        self.assertEqual(info.protocol, PROTOCOL)
 
 
     def test_tiff_info_from_image(self):
@@ -227,7 +213,7 @@ class InfoUnit(loris_t.LorisTest):
         ident = self.test_tiff_id
         uri = self.test_tiff_uri
 
-        info = img_info.ImageInfo(self.app, uri, fp, fmt)
+        info = img_info.ImageInfo(self.app, fp, fmt)
 
         profile = ["http://iiif.io/api/image/2/level2.json", {
                 "formats": [ "jpg", "png", "gif", "webp", "tif" ],
@@ -248,8 +234,6 @@ class InfoUnit(loris_t.LorisTest):
         self.assertEqual(info.sizes, self.test_tiff_sizes)
         self.assertEqual(info.profile.compliance_uri, profile[0])
         self.assertEqual(info.profile.description, profile[1])
-        self.assertEqual(info.base_uri, uri)
-        self.assertEqual(info.protocol, PROTOCOL)
 
     def test_info_from_json(self):
         json_fp = self.test_jp2_color_info_fp
@@ -275,9 +259,7 @@ class InfoUnit(loris_t.LorisTest):
         self.assertEqual(info.profile.compliance_uri, profile[0])
         self.assertEqual(info.profile.description, profile[1])
         self.assertEqual(info.tiles, self.test_jp2_color_tiles)
-        self.assertEqual(info.base_uri, self.test_jp2_color_uri)
         self.assertEqual(info.sizes, self.test_jp2_color_sizes)
-        self.assertEqual(info.protocol, PROTOCOL)
 
     def test_extrainfo_appears_in_iiif_json(self):
         info = ImageInfo(
@@ -292,14 +274,14 @@ class InfoUnit(loris_t.LorisTest):
         )
         info.from_image_file()
 
-        iiif_json = json.loads(info.to_iiif_json())
+        iiif_json = json.loads(info.to_iiif_json(base_uri='http://localhost/1234'))
         assert iiif_json['license'] == 'CC-BY'
         assert iiif_json['logo'] == 'logo.png'
         assert iiif_json['service'] == {'@id': 'my_service'}
         assert iiif_json['attribution'] == 'Author unknown'
 
 
-class TestImageInfo(object):
+class TestImageInfo:
 
     def test_extrainfo_can_override_attributes(self):
         info = ImageInfo(extra={'extraInfo': {
@@ -437,7 +419,6 @@ class InfoFunctional(loris_t.LorisTest):
         self.assertEqual(info.profile.compliance_uri, profile[0])
         self.assertEqual(info.profile.description, profile[1])
         self.assertEqual(info.tiles, self.test_jp2_color_tiles)
-        self.assertEqual(info.base_uri, self.test_jp2_color_uri)
 
     def test_json_ld_headers(self):
         'We should get jsonld if we ask for it'
@@ -479,8 +460,7 @@ class TestInfoCache(loris_t.LorisTest):
         path = self.test_jp2_color_fp
         req = webapp_t._get_werkzeug_request(path=path)
 
-        info = img_info.ImageInfo(self.app, self.test_jp2_color_uri,
-            self.test_jp2_color_fp, self.test_jp2_color_fmt)
+        info = img_info.ImageInfo(self.app, self.test_jp2_color_fp, self.test_jp2_color_fmt)
 
         cache[req] = info
         return (cache, req)
@@ -582,7 +562,6 @@ class TestInfoCache(loris_t.LorisTest):
 
         info = img_info.ImageInfo(
             app=self.app,
-            base_uri=self.test_jpeg_uri,
             src_img_fp=self.test_jpeg_fp,
             src_format=self.test_jpeg_fmt
         )

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -65,7 +65,7 @@ class InfoUnit(loris_t.LorisTest):
         self.assertEqual(info.profile.description, profile[1])
         self.assertEqual(info.tiles, self.test_jp2_color_tiles)
         self.assertEqual(info.sizes, self.test_jp2_color_sizes)
-        self.assertEqual(info.ident, uri)
+        self.assertEqual(info.base_uri, uri)
         self.assertEqual(info.protocol, PROTOCOL)
 
         self.app.max_size_above_full = 0
@@ -138,7 +138,7 @@ class InfoUnit(loris_t.LorisTest):
         self.assertEqual(info.profile.description, profile[1])
         self.assertEqual(info.tiles, self.test_jp2_gray_tiles)
         self.assertEqual(info.sizes, self.test_jp2_gray_sizes)
-        self.assertEqual(info.ident, uri)
+        self.assertEqual(info.base_uri, uri)
         self.assertEqual(info.protocol, PROTOCOL)
 
     def test_info_from_jpg_marked_as_jp2(self):
@@ -187,7 +187,7 @@ class InfoUnit(loris_t.LorisTest):
         self.assertEqual(info.profile.compliance_uri, profile[0])
         self.assertEqual(info.profile.description, profile[1])
         self.assertEqual(info.sizes, self.test_jpeg_sizes)
-        self.assertEqual(info.ident, uri)
+        self.assertEqual(info.base_uri, uri)
         self.assertEqual(info.protocol, PROTOCOL)
 
     def test_png_info_from_image(self):
@@ -217,7 +217,7 @@ class InfoUnit(loris_t.LorisTest):
         self.assertEqual(info.profile.compliance_uri, profile[0])
         self.assertEqual(info.profile.description, profile[1])
         self.assertEqual(info.sizes, self.test_png_sizes)
-        self.assertEqual(info.ident, uri)
+        self.assertEqual(info.base_uri, uri)
         self.assertEqual(info.protocol, PROTOCOL)
 
 
@@ -248,7 +248,7 @@ class InfoUnit(loris_t.LorisTest):
         self.assertEqual(info.sizes, self.test_tiff_sizes)
         self.assertEqual(info.profile.compliance_uri, profile[0])
         self.assertEqual(info.profile.description, profile[1])
-        self.assertEqual(info.ident, uri)
+        self.assertEqual(info.base_uri, uri)
         self.assertEqual(info.protocol, PROTOCOL)
 
     def test_info_from_json(self):
@@ -275,7 +275,7 @@ class InfoUnit(loris_t.LorisTest):
         self.assertEqual(info.profile.compliance_uri, profile[0])
         self.assertEqual(info.profile.description, profile[1])
         self.assertEqual(info.tiles, self.test_jp2_color_tiles)
-        self.assertEqual(info.ident, self.test_jp2_color_uri)
+        self.assertEqual(info.base_uri, self.test_jp2_color_uri)
         self.assertEqual(info.sizes, self.test_jp2_color_sizes)
         self.assertEqual(info.protocol, PROTOCOL)
 
@@ -437,7 +437,7 @@ class InfoFunctional(loris_t.LorisTest):
         self.assertEqual(info.profile.compliance_uri, profile[0])
         self.assertEqual(info.profile.description, profile[1])
         self.assertEqual(info.tiles, self.test_jp2_color_tiles)
-        self.assertEqual(info.ident, self.test_jp2_color_uri)
+        self.assertEqual(info.base_uri, self.test_jp2_color_uri)
 
     def test_json_ld_headers(self):
         'We should get jsonld if we ask for it'
@@ -582,7 +582,7 @@ class TestInfoCache(loris_t.LorisTest):
 
         info = img_info.ImageInfo(
             app=self.app,
-            ident=self.test_jpeg_uri,
+            base_uri=self.test_jpeg_uri,
             src_img_fp=self.test_jpeg_fp,
             src_format=self.test_jpeg_fmt
         )

--- a/tests/parameters_t.py
+++ b/tests/parameters_t.py
@@ -28,7 +28,7 @@ class _ParameterTest(loris_t.LorisTest):
         fmt = self.test_jp2_color_fmt
         ident = self.test_jp2_color_id
         uri = self.test_jp2_color_uri
-        ii = img_info.ImageInfo(self.app, uri, fp, fmt)
+        ii = img_info.ImageInfo(self.app, fp, fmt)
         return ii
 
     def _get_info_long_x(self):
@@ -37,7 +37,7 @@ class _ParameterTest(loris_t.LorisTest):
         fmt = self.test_jpeg_fmt
         ident = self.test_jpeg_id
         uri = self.test_jpeg_uri
-        ii = img_info.ImageInfo(self.app, uri, fp, fmt)
+        ii = img_info.ImageInfo(self.app, fp, fmt)
         return ii
 
 class TestRegionParameter(_ParameterTest):

--- a/tests/webapp_t.py
+++ b/tests/webapp_t.py
@@ -14,6 +14,7 @@ from werkzeug.wrappers import BaseResponse, Request
 
 from loris import img_info, webapp
 from loris.authorizer import NullAuthorizer
+from loris.constants import PROTOCOL
 from loris.loris_exception import ConfigError
 from loris.transforms import KakaduJP2Transformer, OPJ_JP2Transformer
 from loris.webapp import get_debug_config, Loris
@@ -403,6 +404,7 @@ class InfoRequests(loris_t.LorisTest):
         resp = self.client.get(uri)
         info = json.loads(resp.data.decode('utf8'))
         assert info['@id'] == 'http://localhost/01%2F02%2F0001.jp2' #base URI of the image including scheme, server, prefix and identifier without a trailing slash
+        assert info['protocol'] == PROTOCOL
 
     def test_access_control_allow_origin_on_info_requests(self):
         uri = '/%s/info.json' % (self.test_jp2_color_id,)


### PR DESCRIPTION
The "ident" is actually the base_uri, and it can be passed in as an argument when a client wants the full IIIF info.json. Otherwise it's not necessary, and confusingly named.

Also remove "protocol" from ImageInfo - it's a constant that can just be referenced when needed.