### PR TITLE
InfoCache

### DIFF
--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -11,6 +11,7 @@ import attr
 from PIL import Image
 
 from loris.constants import COMPLIANCE, CONTEXT, OPTIONAL_FEATURES, PROTOCOL
+from loris.identifiers import CacheNamer
 from loris.jp2_extractor import JP2Extractor, JP2ExtractionError
 from loris.loris_exception import ImageInfoException
 from loris.utils import mkdir_p
@@ -296,7 +297,7 @@ class InfoCache(object):
         self._lock = Lock()
 
     def _get_ident_dir_path(self, ident):
-        return os.path.join(self.root, unquote(ident))
+        return os.path.join(self.root, CacheNamer.cache_directory_name(ident=ident))
 
     def _get_info_fp(self, ident):
         return os.path.join(self._get_ident_dir_path(ident), 'info.json')

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -5,7 +5,6 @@ from math import ceil
 from threading import Lock
 import json
 import os
-from urllib.parse import unquote
 
 import attr
 from PIL import Image
@@ -17,8 +16,6 @@ from loris.loris_exception import ImageInfoException
 from loris.utils import mkdir_p
 
 logger = getLogger(__name__)
-
-STAR_DOT_JSON = '*.json'
 
 PIL_MODES_TO_QUALITIES = {
     # Thanks to http://stackoverflow.com/a/1996609/714478

--- a/loris/parameters.py
+++ b/loris/parameters.py
@@ -52,7 +52,7 @@ class RegionParameter(object):
 
         Args:
             uri_value (str): The region slice of an IIIF image request URI.
-            image_info (ImgInfo)
+            image_info (ImageInfo)
 
         Raises:
             SyntaxException

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -176,7 +176,7 @@ class SimpleHTTPResolver(_AbstractResolver):
      * `key`, path to an SSL client key to use for authentication.
     '''
     def __init__(self, config):
-        super(SimpleHTTPResolver, self).__init__(config)
+        super().__init__(config)
 
         self.source_prefix = self.config.get('source_prefix', '')
 
@@ -201,7 +201,6 @@ class SimpleHTTPResolver(_AbstractResolver):
         self._ident_regex_checker = IdentRegexChecker(
             ident_regex=self.config.get('ident_regex')
         )
-        self._cache_namer = CacheNamer()
 
         if 'cache_root' in self.config:
             self.cache_root = self.config['cache_root']

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -550,7 +550,7 @@ class Loris(object):
 
     def _get_info(self,ident,request,base_uri):
         if self.enable_caching:
-            in_cache = request in self.info_cache
+            in_cache = ident in self.info_cache
         else:
             in_cache = False
 
@@ -559,8 +559,8 @@ class Loris(object):
         #   If we don't see src_format, that means it's old cache data, so just
         #   ignore it and cache new ImageInfo.
         #   TODO: remove src_format check in Loris 4.0.
-        if in_cache and self.info_cache[request][0].src_format:
-            return self.info_cache[request]
+        if in_cache and self.info_cache[ident][0].src_format:
+            return self.info_cache[ident]
         else:
 
             info = self.resolver.resolve(self, ident, base_uri)
@@ -575,9 +575,9 @@ class Loris(object):
             # store
             if self.enable_caching:
                 self.logger.debug('ident used to store %s: %s', ident, ident)
-                self.info_cache[request] = info
+                self.info_cache[ident] = info
                 # pick up the timestamp... :()
-                info,last_mod = self.info_cache[request]
+                info,last_mod = self.info_cache[ident]
             else:
                 last_mod = None
 

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -3,7 +3,6 @@ from os import path
 import json
 import tempfile
 from datetime import datetime
-from urllib.parse import unquote
 
 import pytest
 from werkzeug.datastructures import Headers
@@ -11,7 +10,7 @@ from werkzeug.datastructures import Headers
 from loris import img_info, loris_exception
 from loris.img_info import ImageInfo, Profile
 from loris.loris_exception import ImageInfoException
-from tests import loris_t, webapp_t
+from tests import loris_t
 
 
 class MockApp:


### PR DESCRIPTION
Update InfoCache to key off the image identifier, instead of the request url. Also, use the same naming scheme as the SimpleHttpResolver uses for src images (eg. 12/abc/def/...).

Note: this changes the cache layout, so it would invalidate all the objects in the cache and require the cache to be built up again.