### PR TITLE
ImageInfo/auth_rules updates

### DIFF
--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -80,12 +80,11 @@ class ImageInfo(JP2Extractor):
         auth_rules (dict): extra information about authorization [non IIIF]
 
     '''
-    __slots__ = ('scaleFactors', 'width', 'tiles', 'height',
-        'profile', 'sizes', 'service',
-        'attribution', 'logo', 'license', 'auth_rules',
-        'src_format', 'src_img_fp', 'color_profile_bytes')
+    __slots__ = ('width', 'height', 'scaleFactors', 'sizes', 'tiles',
+        'profile', 'service', 'attribution', 'license', 'logo',
+        'src_img_fp', 'src_format', 'color_profile_bytes', 'auth_rules')
 
-    def __init__(self, app=None, src_img_fp="", src_format="", attribution=None, logo=None, license=None, service=None, auth_rules=None):
+    def __init__(self, app=None, service=None, attribution=None, license=None, logo=None, src_img_fp="", src_format="", auth_rules=None):
         self.src_img_fp = src_img_fp
         self.src_format = src_format
         self.attribution = attribution

--- a/loris/img_info.py
+++ b/loris/img_info.py
@@ -57,7 +57,7 @@ class EnhancedJSONEncoder(json.JSONEncoder):
 
 class ImageInfo(JP2Extractor):
     '''Info about the image.
-    See: <http://iiif.io/api/image/>
+    See: <http://iiif.io/api/image/>, <https://iiif.io/api/image/2.1/#complete-response>
 
     Slots:
         width (int)
@@ -65,9 +65,14 @@ class ImageInfo(JP2Extractor):
         scaleFactors [(int)]
         sizes [(str)]: the optimal sizes of the image to request
         tiles: [{}]
-        service (dict): services associated with the image
         profile (Profile): Features supported by the server/available for
             this image
+        service [{}]: optional - services associated with the image
+        attribution [{}]: optional - text that must be shown when content obtained from the Image API service is 
+            displayed or used
+        license []: optional - link to an external resource that describes the license or rights statement under which
+            content obtained from the Image API service may be used
+        logo {}: optional - small image that represents an individual or organization associated with the content
 
         src_img_fp (str): the absolute path on the file system [non IIIF]
         src_format (str): the format of the source image file [non IIIF]
@@ -80,27 +85,14 @@ class ImageInfo(JP2Extractor):
         'attribution', 'logo', 'license', 'auth_rules',
         'src_format', 'src_img_fp', 'color_profile_bytes')
 
-    def __init__(self, app=None, src_img_fp="", src_format="", extra={}):
+    def __init__(self, app=None, src_img_fp="", src_format="", attribution=None, logo=None, license=None, service=None, auth_rules=None):
         self.src_img_fp = src_img_fp
         self.src_format = src_format
-        self.attribution = None
-        self.logo = None
-        self.license = None
-        self.service = {}
-        self.auth_rules = extra
-
-        # The extraInfo parameter can be used to override specific attributes.
-        # If there are extra attributes, drop an error.
-        bad_attrs = []
-        for (k, v) in extra.get('extraInfo', {}).items():
-            try:
-                setattr(self, k, v)
-            except AttributeError:
-                bad_attrs.append(k)
-        if bad_attrs:
-            raise ImageInfoException(
-                "Invalid parameters in extraInfo: %s." % ', '.join(bad_attrs)
-            )
+        self.attribution = attribution
+        self.logo = logo
+        self.license = license
+        self.service = service or {}
+        self.auth_rules = auth_rules or {}
 
         # If constructed from JSON, the pixel info will already be processed
         if app:

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -135,7 +135,7 @@ class SimpleFSResolver(_AbstractResolver):
         source_fp = self.source_file_path(ident)
         format_ = self.format_from_ident(ident)
         auth_rules = self.get_auth_rules(ident, source_fp)
-        return ImageInfo(app, source_fp, format_, auth_rules=auth_rules)
+        return ImageInfo(app=app, src_img_fp=source_fp, src_format=format_, auth_rules=auth_rules)
 
 
 class ExtensionNormalizingFSResolver(SimpleFSResolver):
@@ -367,7 +367,7 @@ class SimpleHTTPResolver(_AbstractResolver):
             cached_file_path = self.copy_to_cache(ident)
         format_ = self.get_format(cached_file_path, None)
         auth_rules = self.get_auth_rules(ident, cached_file_path)
-        return ImageInfo(app, cached_file_path, format_, auth_rules=auth_rules)
+        return ImageInfo(app=app, src_img_fp=cached_file_path, src_format=format_, auth_rules=auth_rules)
 
 
 class TemplateHTTPResolver(SimpleHTTPResolver):
@@ -549,4 +549,4 @@ class SourceImageCachingResolver(_AbstractResolver):
         cache_fp = self.cache_file_path(ident)
         format_ = self.format_from_ident(ident)
         auth_rules = self.get_auth_rules(ident, cache_fp)
-        return ImageInfo(app, cache_fp, format_, auth_rules=auth_rules)
+        return ImageInfo(app=app, src_img_fp=cache_fp, src_format=format_, auth_rules=auth_rules)

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -91,8 +91,7 @@ class _AbstractResolver:
         xjsfp = source_fp.rsplit('.', 1)[0] + "." + self.auth_rules_ext
         if exists(xjsfp):
             with open(xjsfp) as fh:
-                xjs = json.load(fh)
-            return xjs
+                return json.load(fh)
         else:
             return {}
 

--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -25,13 +25,13 @@ from loris.img_info import ImageInfo
 logger = getLogger(__name__)
 
 
-class _AbstractResolver(object):
+class _AbstractResolver:
 
     def __init__(self, config):
         self.config = config
         if config:
             self.auth_rules_ext = self.config.get('auth_rules_ext', 'rules.json')
-            self.use_extra_info = self.config.get('use_extra_info', True)
+            self.use_auth_rules = self.config.get('use_auth_rules', False)
 
     def is_resolvable(self, ident):
         """
@@ -65,12 +65,10 @@ class _AbstractResolver(object):
         cn = self.__class__.__name__
         raise NotImplementedError('resolve() not implemented for %s' % (cn,))
 
-    def get_extra_info(self, ident, source_fp):
+    def get_auth_rules(self, ident, source_fp):
         """
-        Given the identifier and any resolved source file, find the associated
-        extra information to include in info.json, plus any additional authorizer
-        specific information.  It might end up there after being copied by a
-        caching implementation, or live there permanently.
+        Given the identifier and any resolved source file (ie. on the filesystem), grab the associated
+        authentication rules from the filesystem (if they exist).
 
         Args:
             ident (str):
@@ -80,11 +78,12 @@ class _AbstractResolver(object):
         Returns:
             dict: The dict of information to embed in info.json
         """
+        if not self.use_auth_rules:
+            return {}
         xjsfp = source_fp.rsplit('.', 1)[0] + "." + self.auth_rules_ext
         if exists(xjsfp):
-            fh = open(xjsfp)
-            xjs = json.load(fh)
-            fh.close()
+            with open(xjsfp) as fh:
+                xjs = json.load(fh)
             return xjs
         else:
             return {}
@@ -130,14 +129,13 @@ class SimpleFSResolver(_AbstractResolver):
         return not self.source_file_path(ident) is None
 
     def resolve(self, app, ident, base_uri):
-
         if not self.is_resolvable(ident):
             self.raise_404_for_ident(ident)
 
         source_fp = self.source_file_path(ident)
         format_ = self.format_from_ident(ident)
-        extra = self.get_extra_info(ident, source_fp)
-        return ImageInfo(app, source_fp, format_, extra)
+        auth_rules = self.get_auth_rules(ident, source_fp)
+        return ImageInfo(app, source_fp, format_, auth_rules=auth_rules)
 
 
 class ExtensionNormalizingFSResolver(SimpleFSResolver):
@@ -347,19 +345,19 @@ class SimpleHTTPResolver(_AbstractResolver):
         # These files are < 2k in size, so fetch in one go.
         # Assumes that the rules will be next to the image
         # cache_dir is image specific, so this is easy
-
-        bits = split(source_url)
-        fn = bits[1].rsplit('.', 1)[0] + "." + self.auth_rules_ext
-        rules_url = bits[0] + '/' + fn
-        try:
-            resp = requests.get(rules_url)
-            if resp.status_code == 200:
-                local_rules_fp = join(cache_dir, "loris_cache." + self.auth_rules_ext)
-                if not exists(local_rules_fp):
-                    with open(local_rules_fp, 'w') as fh:
-                        fh.write(resp.text)
-        except requests.exceptions.RequestException:
-            pass
+        if self.use_auth_rules:
+            bits = split(source_url)
+            fn = bits[1].rsplit('.', 1)[0] + "." + self.auth_rules_ext
+            rules_url = bits[0] + '/' + fn
+            try:
+                resp = requests.get(rules_url)
+                if resp.status_code == 200:
+                    local_rules_fp = join(cache_dir, "loris_cache." + self.auth_rules_ext)
+                    if not exists(local_rules_fp):
+                        with open(local_rules_fp, 'w') as fh:
+                            fh.write(resp.text)
+            except requests.exceptions.RequestException:
+                pass
 
         return local_fp
 
@@ -368,11 +366,8 @@ class SimpleHTTPResolver(_AbstractResolver):
         if not cached_file_path:
             cached_file_path = self.copy_to_cache(ident)
         format_ = self.get_format(cached_file_path, None)
-        if self.use_extra_info:
-            extra = self.get_extra_info(ident, cached_file_path)
-        else:
-            extra = {}
-        return ImageInfo(app, cached_file_path, format_, extra)
+        auth_rules = self.get_auth_rules(ident, cached_file_path)
+        return ImageInfo(app, cached_file_path, format_, auth_rules=auth_rules)
 
 
 class TemplateHTTPResolver(SimpleHTTPResolver):
@@ -553,5 +548,5 @@ class SourceImageCachingResolver(_AbstractResolver):
 
         cache_fp = self.cache_file_path(ident)
         format_ = self.format_from_ident(ident)
-        extra = self.get_extra_info(ident, cache_fp)
-        return ImageInfo(app, cache_fp, format_, extra)
+        auth_rules = self.get_auth_rules(ident, cache_fp)
+        return ImageInfo(app, cache_fp, format_, auth_rules=auth_rules)

--- a/tests/authorizer_t.py
+++ b/tests/authorizer_t.py
@@ -48,7 +48,7 @@ class Test_NullAuthorizer(unittest.TestCase):
         fp = "img/test.png"
         fmt = "png"
         self.authorizer = NullAuthorizer({})
-        self.info = ImageInfo(None, fp, fmt)
+        self.info = ImageInfo(app=None, src_img_fp=fp, src_format=fmt)
         self.request = MockRequest()
 
     def test_is_protected(self):
@@ -69,7 +69,7 @@ class Test_NooneAuthorizer(unittest.TestCase):
         fp = "img/test.png"
         fmt = "png"
         self.authorizer = NooneAuthorizer({})
-        self.info = ImageInfo(None, fp, fmt)
+        self.info = ImageInfo(app=None, src_img_fp=fp, src_format=fmt)
         self.request = MockRequest()
 
     def test_is_protected(self):
@@ -90,9 +90,9 @@ class Test_SingleDegradingAuthorizer(unittest.TestCase):
         fp = "img/test.png"
         fmt = "png"
         self.authorizer = SingleDegradingAuthorizer({})
-        self.badInfo = ImageInfo(None, fp, fmt)
+        self.badInfo = ImageInfo(app=None, src_img_fp=fp, src_format=fmt)
         self.okayIdent = "67352ccc-d1b0-11e1-89ae-279075081939.jp2"
-        self.okayInfo = ImageInfo(None, "img/%s" % self.okayIdent, "jp2")
+        self.okayInfo = ImageInfo(app=None, src_img_fp="img/%s" % self.okayIdent, src_format="jp2")
         self.request = MockRequest()
 
     def test_is_protected(self):
@@ -120,9 +120,9 @@ class Test_RulesAuthorizer(unittest.TestCase):
             {"cookie_secret": b"4rakTQJDyhaYgoew802q78pNnsXR7ClvbYtAF1YC87o=",
             "token_secret": b"hyQijpEEe9z1OB9NOkHvmSA4lC1B4lu1n80bKNx0Uz0=",
             "salt": b"4rakTQJD4lC1B4lu"})
-        self.badInfo = ImageInfo(None, fp, fmt)
+        self.badInfo = ImageInfo(app=None, src_img_fp=fp, src_format=fmt)
         self.okayIdent = "67352ccc-d1b0-11e1-89ae-279075081939.jp2"
-        self.okayInfo = ImageInfo(None, "img/%s" % self.okayIdent, "jp2")
+        self.okayInfo = ImageInfo(app=None, src_img_fp="img/%s" % self.okayIdent, src_format="jp2")
 
         self.origin = "localhost"
         # role to get access is "test"

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -262,44 +262,23 @@ class InfoUnit(loris_t.LorisTest):
         self.assertEqual(info.tiles, self.test_jp2_color_tiles)
         self.assertEqual(info.sizes, self.test_jp2_color_sizes)
 
-    def test_extrainfo_appears_in_iiif_json(self):
+    def test_rights_licensing_properties_in_iiif_json(self):
         info = ImageInfo(
             src_img_fp=self.test_jpeg_fp,
             src_format=self.test_jpeg_fmt,
-            extra={'extraInfo': {
-                'license': 'CC-BY',
-                'logo': 'logo.png',
-                'service': {'@id': 'my_service'},
-                'attribution': 'Author unknown',
-            }}
+            license='CC-BY',
+            logo='logo.png',
+            attribution='Author unknown',
         )
         info.from_image_file()
 
         iiif_json = json.loads(info.to_iiif_json(base_uri='http://localhost/1234'))
         assert iiif_json['license'] == 'CC-BY'
         assert iiif_json['logo'] == 'logo.png'
-        assert iiif_json['service'] == {'@id': 'my_service'}
         assert iiif_json['attribution'] == 'Author unknown'
 
 
 class TestImageInfo:
-
-    def test_extrainfo_can_override_attributes(self):
-        info = ImageInfo(extra={'extraInfo': {
-            'license': 'CC-BY',
-            'logo': 'logo.png',
-            'service': {'@id': 'my_service'},
-            'attribution': 'Author unknown',
-        }})
-        assert info.license == 'CC-BY'
-        assert info.logo == 'logo.png'
-        assert info.service == {'@id': 'my_service'}
-        assert info.attribution == 'Author unknown'
-
-    def test_invalid_extra_info_is_imageinfoexception(self):
-        with pytest.raises(ImageInfoException) as exc:
-            ImageInfo(extra={'extraInfo': {'foo': 'bar', 'baz': 'bat'}})
-        assert 'Invalid parameters in extraInfo' in str(exc.value)
 
     @pytest.mark.parametrize('src_format', ['', None, 'imgX'])
     def test_invalid_src_format_is_error(self, src_format):

--- a/tests/img_info_t.py
+++ b/tests/img_info_t.py
@@ -52,7 +52,7 @@ class InfoUnit(loris_t.LorisTest):
 
         #test that sizeAboveFull isn't in profile if max_size_above_full is > 0 and <= 100
         self.app.max_size_above_full = 80
-        info = img_info.ImageInfo(self.app, fp, fmt)
+        info = img_info.ImageInfo(app=self.app, src_img_fp=fp, src_format=fmt)
 
         self.assertEqual(info.width, self.test_jp2_color_dims[0])
         self.assertEqual(info.height, self.test_jp2_color_dims[1])
@@ -62,7 +62,7 @@ class InfoUnit(loris_t.LorisTest):
         self.assertEqual(info.sizes, self.test_jp2_color_sizes)
 
         self.app.max_size_above_full = 0
-        info = img_info.ImageInfo(self.app, fp, fmt)
+        info = img_info.ImageInfo(app=self.app, src_img_fp=fp, src_format=fmt)
         self.assertTrue('sizeAboveFull' in info.profile.description['supports'])
         self.app.max_size_above_full = 200
 
@@ -73,7 +73,7 @@ class InfoUnit(loris_t.LorisTest):
         ident = self.test_jp2_with_precincts_id
         uri = self.test_jp2_with_precincts_uri
 
-        info = img_info.ImageInfo(self.app, fp, fmt)
+        info = img_info.ImageInfo(app=self.app, src_img_fp=fp, src_format=fmt)
 
         self.assertEqual(info.tiles, self.test_jp2_with_precincts_tiles)
         self.assertEqual(info.sizes, self.test_jp2_with_precincts_sizes)
@@ -85,7 +85,7 @@ class InfoUnit(loris_t.LorisTest):
         uri = self.test_jp2_with_embedded_profile_uri
         profile_copy_fp = self.test_jp2_embedded_profile_copy_fp
 
-        info = img_info.ImageInfo(self.app, fp, fmt)
+        info = img_info.ImageInfo(app=self.app, src_img_fp=fp, src_format=fmt)
 
         with open(self.test_jp2_embedded_profile_copy_fp, 'rb') as fixture_bytes:
             self.assertEqual(info.color_profile_bytes, fixture_bytes.read())
@@ -96,7 +96,7 @@ class InfoUnit(loris_t.LorisTest):
         ident = self.test_jp2_color_id
         uri = self.test_jp2_color_uri
 
-        info = img_info.ImageInfo(self.app, fp, fmt)
+        info = img_info.ImageInfo(app=self.app, src_img_fp=fp, src_format=fmt)
         self.assertEqual(info.color_profile_bytes, None)
 
     def test_gray_jp2_info_from_image(self):
@@ -123,7 +123,7 @@ class InfoUnit(loris_t.LorisTest):
             }
         ]
 
-        info = img_info.ImageInfo(self.app, fp, fmt)
+        info = img_info.ImageInfo(app=self.app, src_img_fp=fp, src_format=fmt)
 
         self.assertEqual(info.width, self.test_jp2_gray_dims[0])
         self.assertEqual(info.height, self.test_jp2_gray_dims[1])
@@ -138,7 +138,7 @@ class InfoUnit(loris_t.LorisTest):
         ident = '01%2f03%2f0001.jpg'
         uri = '%s/%s' % (self.URI_BASE, ident)
         with self.assertRaises(loris_exception.ImageInfoException) as cm:
-            img_info.ImageInfo(self.app, fp, fmt)
+            img_info.ImageInfo(app=self.app, src_img_fp=fp, src_format=fmt)
         self.assertEqual(str(cm.exception), 'Invalid JP2 file')
 
     def test_info_from_invalid_src_format(self):
@@ -148,7 +148,7 @@ class InfoUnit(loris_t.LorisTest):
         uri = '%s/%s' % (self.URI_BASE, ident)
         error_message = "Didn\'t get a source format, or at least one we recognize ('invalid_format')."
         with self.assertRaises(loris_exception.ImageInfoException) as cm:
-            img_info.ImageInfo(self.app, fp, fmt)
+            img_info.ImageInfo(app=self.app, src_img_fp=fp, src_format=fmt)
         self.assertEqual(str(cm.exception), error_message)
 
     def test_jpeg_info_from_image(self):
@@ -157,7 +157,7 @@ class InfoUnit(loris_t.LorisTest):
         ident = self.test_jpeg_id
         uri = self.test_jpeg_uri
 
-        info = img_info.ImageInfo(self.app, fp, fmt)
+        info = img_info.ImageInfo(app=self.app, src_img_fp=fp, src_format=fmt)
 
         profile = ["http://iiif.io/api/image/2/level2.json", {
                 "formats": [ "jpg", "png", "gif", "webp", "tif" ],
@@ -185,7 +185,7 @@ class InfoUnit(loris_t.LorisTest):
         ident = self.test_png_id
         uri = self.test_png_uri
 
-        info = img_info.ImageInfo(self.app, fp, fmt)
+        info = img_info.ImageInfo(app=self.app, src_img_fp=fp, src_format=fmt)
 
         profile = ["http://iiif.io/api/image/2/level2.json", {
                 "formats": [ "jpg", "png", "gif", "webp", "tif" ],
@@ -214,7 +214,7 @@ class InfoUnit(loris_t.LorisTest):
         ident = self.test_tiff_id
         uri = self.test_tiff_uri
 
-        info = img_info.ImageInfo(self.app, fp, fmt)
+        info = img_info.ImageInfo(app=self.app, src_img_fp=fp, src_format=fmt)
 
         profile = ["http://iiif.io/api/image/2/level2.json", {
                 "formats": [ "jpg", "png", "gif", "webp", "tif" ],
@@ -437,7 +437,7 @@ class TestInfoCache(loris_t.LorisTest):
         """
         cache = img_info.InfoCache(root=self.SRC_IMAGE_CACHE)
 
-        info = img_info.ImageInfo(self.app, self.test_jp2_color_fp, self.test_jp2_color_fmt)
+        info = img_info.ImageInfo(app=self.app, src_img_fp=self.test_jp2_color_fp, src_format=self.test_jp2_color_fmt)
 
         cache[self.test_jp2_color_id] = info
         return (cache, self.test_jp2_color_id)

--- a/tests/img_t.py
+++ b/tests/img_t.py
@@ -32,7 +32,7 @@ class TestImageRequest:
         (('id4', 'full', '!80,20', '30', 'default', 'jpg'), False),
     ])
     def test_is_canonical(self, args, is_canonical):
-        info = img_info.ImageInfo(None)
+        info = img_info.ImageInfo()
         info.width = 100
         info.height = 100
         request = img.ImageRequest(*args)
@@ -84,7 +84,7 @@ class Test_ImageCache(loris_t.LorisTest):
 
     def test_cache_dir_already_exists(self):
         ident = 'id1'
-        image_info = img_info.ImageInfo(None)
+        image_info = img_info.ImageInfo()
         image_info.width = 100
         image_info.height = 100
         image_request = img.ImageRequest(ident, 'full', 'full', '0', 'default', 'jpg')

--- a/tests/parameters_t.py
+++ b/tests/parameters_t.py
@@ -15,7 +15,7 @@ from tests import loris_t
 
 def build_image_info(width=100, height=100):
     """Produces an ``ImageInfo`` object of the given dimensions."""
-    info = img_info.ImageInfo(None)
+    info = img_info.ImageInfo()
     info.width = width
     info.height = height
     return info
@@ -28,7 +28,7 @@ class _ParameterTest(loris_t.LorisTest):
         fmt = self.test_jp2_color_fmt
         ident = self.test_jp2_color_id
         uri = self.test_jp2_color_uri
-        ii = img_info.ImageInfo(self.app, fp, fmt)
+        ii = img_info.ImageInfo(app=self.app, src_img_fp=fp, src_format=fmt)
         return ii
 
     def _get_info_long_x(self):
@@ -37,7 +37,7 @@ class _ParameterTest(loris_t.LorisTest):
         fmt = self.test_jpeg_fmt
         ident = self.test_jpeg_id
         uri = self.test_jpeg_uri
-        ii = img_info.ImageInfo(self.app, fp, fmt)
+        ii = img_info.ImageInfo(app=self.app, src_img_fp=fp, src_format=fmt)
         return ii
 
 class TestRegionParameter(_ParameterTest):

--- a/tests/resolver_t.py
+++ b/tests/resolver_t.py
@@ -107,10 +107,11 @@ class Test_SimpleFSResolver(loris_t.LorisTest):
             with open(os.path.join(tmp, rules_filename), 'wb') as f:
                 f.write(json.dumps({'rule': 1}).encode('utf8'))
             config = {
-                'src_img_roots' : [tmp]
+                'src_img_roots' : [tmp],
+                'use_auth_rules': True
             }
             resolver = SimpleFSResolver(config=config)
-            assert resolver.get_extra_info(ident, source_fp) == {'rule': 1}
+            assert resolver.get_auth_rules(ident, source_fp) == {'rule': 1}
 
 
 class Test_SourceImageCachingResolver(loris_t.LorisTest):

--- a/tests/simple_http_resolver_ut.py
+++ b/tests/simple_http_resolver_ut.py
@@ -174,7 +174,7 @@ class SimpleHTTPResolverConfigTest(unittest.TestCase):
             'uri_resolvable': True,
             'user': 'TestUser',
             'pw': 'TestPW',
-            'use_extra_info': False,
+            'use_auth_rules': True,
         }
 
         resolver = SimpleHTTPResolver(config)
@@ -186,7 +186,7 @@ class SimpleHTTPResolverConfigTest(unittest.TestCase):
         self.assertEqual(resolver.uri_resolvable, True)
         self.assertEqual(resolver.user, 'TestUser')
         self.assertEqual(resolver.pw, 'TestPW')
-        self.assertEqual(resolver.use_extra_info, False)
+        self.assertEqual(resolver.use_auth_rules, True)
 
     def test_barebones_config(self):
         config = {
@@ -203,4 +203,4 @@ class SimpleHTTPResolverConfigTest(unittest.TestCase):
         self.assertEqual(resolver.uri_resolvable, True)
         self.assertEqual(resolver.user, None)
         self.assertEqual(resolver.pw, None)
-        self.assertEqual(resolver.use_extra_info, True)
+        self.assertEqual(resolver.use_auth_rules, False)


### PR DESCRIPTION
1. ImageInfo - rename extra to auth_rules
2. Don't process logo/attribution/... out of extra["extraInfo"], but
allow passing them into ImageInfo as parameters.
3. In the SimpleHttpResolver, only try to fetch rules.json if
use_auth_rules is True.
4. In resolvers, use_auth_rules is now False by default (this will
require anyone using rules.json to update their configuration).