### PR TITLE
Improve the quality and coverage of tests for RulesAuthorizer

### DIFF
--- a/loris/authorizer.py
+++ b/loris/authorizer.py
@@ -195,7 +195,10 @@ class RulesAuthorizer(_AbstractAuthorizer):
             )
 
         if ('salt' in config) and (not isinstance(config['salt'], bytes)):
-            raise ConfigError('"salt" config parameter must be bytes; got %r (%s)' % (config['salt'], type(config['salt'])))
+            raise ConfigError(
+                '"salt" config parameter must be bytes; got %r (%s)' %
+                (config['salt'], type(config['salt']))
+            )
 
     def kdf(self):
         return PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=self.salt,

--- a/loris/authorizer.py
+++ b/loris/authorizer.py
@@ -307,9 +307,9 @@ class RulesAuthorizer(_AbstractAuthorizer):
 
     def is_protected(self, info):
         # Now we can check info.auth_rules
-        # Protected if there's an 'allowed' key, with a non-false value 
-        logger.debug("Called is_protected with %r" % info.auth_rules)
-        return bool('allowed' in info.auth_rules and info.auth_rules['allowed'])
+        # Protected if there's an 'allowed' key, with a non-false value
+        logger.debug("Called is_protected with %r", info.auth_rules)
+        return bool(info.auth_rules.get("allowed"))
 
     def is_authorized(self, info, request):
         if not "allowed" in info.auth_rules:

--- a/loris/authorizer.py
+++ b/loris/authorizer.py
@@ -194,7 +194,7 @@ class RulesAuthorizer(_AbstractAuthorizer):
                 config['use_jwt']
             )
 
-        for param in ("token_secret", "salt"):
+        for param in ("cookie_secret", "token_secret", "salt"):
             try:
                 value = config[param]
             except KeyError:

--- a/loris/authorizer.py
+++ b/loris/authorizer.py
@@ -37,12 +37,12 @@ class _AbstractAuthorizer(object):
             "service": []
         }
 
+        self.context = "http://iiif.io/api/auth/1/context.json"
         self.login_profile = "http://iiif.io/api/auth/1/login"
         self.clickthrough_profile = "http://iiif.io/api/auth/1/clickthrough"
         self.kiosk_profile = "http://iiif.io/api/auth/1/kiosk"
         self.external_profile = "http://iiif.io/api/auth/1/external"
         self.token_profile = "http://iiif.io/api/auth/1/token"
-
 
     def _strip_empty_fields(self, svc):
         # dicts are modified in place
@@ -346,30 +346,38 @@ class RulesAuthorizer(_AbstractAuthorizer):
                 return {"status": "deny"} 
 
     def get_services_info(self, info):
+        extra_info = info.auth_rules.get("extraInfo", {})
 
-        xi = info.auth_rules.get('extraInfo', {})
-        if not xi or not xi.get('service', {}):
-            # look in config for URIs instead of in XI
-            if not self.cookie_service:
-                raise AuthorizerException("No cookie service for authentication")
-            elif not self.token_service:
-                raise AuthorizerException("No token service for authentication")
-            tmpl = self.service_template.copy()
-            tmpl['@id'] = self.cookie_service
-            tmpl['label'] = "Please Login"
-            tmpl['profile'] = self.login_profile
-            self._strip_empty_fields(tmpl)
-            token = self.service_template.copy()
-            token['@id'] = self.token_service
-            token['label'] = "Access Token Service"
-            token['profile'] = self.token_profile
-            self._strip_empty_fields(token)
-            tmpl['service'] = [token]
-            return {"service": tmpl}
-        elif xi and xi.get('service', {}):
-            return {"service": xi['service']}
-        else:
-            raise AuthorizerException("No services for authentication for %s" % info.ident)
+        try:
+            return {"service": extra_info["service"]}
+        except KeyError:
+            pass
+
+        # If there's no service in the extraInfo field, look in config
+        # for URIs instead.
+
+        if not self.cookie_service:
+            raise AuthorizerException("No cookie service for authentication")
+
+        if not self.token_service:
+            raise AuthorizerException("No token service for authentication")
+
+        token_service = {
+            "@context": self.context,
+            "@id": self.token_service,
+            "label": "Access Token Service",
+            "profile": self.token_profile,
+        }
+
+        service = {
+            "@context": self.context,
+            "@id": self.cookie_service,
+            "label": "Please Login",
+            "profile": self.login_profile,
+            "service": token_service
+        }
+
+        return {"service": service}
 
 
 class ExternalAuthorizer(_AbstractAuthorizer):

--- a/loris/authorizer.py
+++ b/loris/authorizer.py
@@ -194,11 +194,17 @@ class RulesAuthorizer(_AbstractAuthorizer):
                 config['use_jwt']
             )
 
-        if ('salt' in config) and (not isinstance(config['salt'], bytes)):
-            raise ConfigError(
-                '"salt" config parameter must be bytes; got %r (%s)' %
-                (config['salt'], type(config['salt']))
-            )
+        for param in ("token_secret", "salt"):
+            try:
+                value = config[param]
+            except KeyError:
+                continue
+
+            if not isinstance(value, bytes):
+                raise ConfigError(
+                    '"%s" config parameter must be bytes; got %r (%s)' %
+                    (param, value, type(value))
+                )
 
     def kdf(self):
         return PBKDF2HMAC(algorithm=hashes.SHA256(), length=32, salt=self.salt,

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -73,13 +73,13 @@ def get_debug_config(debug_jp2_transformer):
     else:
         raise ConfigError('Unrecognized debug JP2 transformer: %r' % debug_jp2_transformer)
 
-    config['authorizer'] = {'impl': 'loris.authorizer.RulesAuthorizer'}
-    config['authorizer']['cookie_secret'] = "4rakTQJDyhaYgoew802q78pNnsXR7ClvbYtAF1YC87o="
-    config['authorizer']['token_secret'] = "hyQijpEEe9z1OB9NOkHvmSA4lC1B4lu1n80bKNx0Uz0="
-    config['authorizer']['roles_key'] = 'roles'
-    config['authorizer']['id_key'] = 'sub'
-
-
+    config['authorizer'] = {
+        "impl": "loris.authorizer.RulesAuthorizer",
+        "cookie_secret": b"4rakTQJDyhaYgoew802q78pNnsXR7ClvbYtAF1YC87o",
+        "token_secret": b"hyQijpEEe9z1OB9NOkHvmSA4lC1B4lu1n80bKNx0Uz0=",
+        "roles_key": "roles",
+        "id_key": "sub",
+    }
 
     return config
 

--- a/tests/authorizer_t.py
+++ b/tests/authorizer_t.py
@@ -283,7 +283,7 @@ class TestRulesAuthorizerPytest:
     @staticmethod
     def create_authorizer(**extra_config):
         config = {
-            "cookie_secret": "123",
+            "cookie_secret": b"123",
             "token_secret": b"123",
         }
         config.update(extra_config)
@@ -303,7 +303,7 @@ class TestRulesAuthorizerPytest:
             {
                 "cookie_service": "cookie.example.com",
                 "token_service": "token.example.com",
-                "cookie_secret": "c00ki3sekr1t",
+                "cookie_secret": b"c00ki3sekr1t",
             },
             "Missing mandatory parameters for RulesAuthorizer: token_secret"
         ),
@@ -311,7 +311,7 @@ class TestRulesAuthorizerPytest:
             {
                 "cookie_service": "cookie.example.com",
                 "token_service": "token.example.com",
-                "cookie_secret": "c00ki3sekr1t",
+                "cookie_secret": b"c00ki3sekr1t",
                 "token_secret": b"t0k3ns3kr1t",
                 "use_jwt": False,
             },
@@ -321,10 +321,10 @@ class TestRulesAuthorizerPytest:
             {
                 "cookie_service": "cookie.example.com",
                 "token_service": "token.example.com",
-                "cookie_secret": "c00ki3sekr1t",
+                "cookie_secret": b"c00ki3sekr1t",
                 "token_secret": u"t0k3ns3kr1t",
                 "use_jwt": False,
-                "salt": u"salt",
+                "salt": b"salt",
             },
             '"token_secret" config parameter must be bytes;'
         ),
@@ -332,7 +332,18 @@ class TestRulesAuthorizerPytest:
             {
                 "cookie_service": "cookie.example.com",
                 "token_service": "token.example.com",
-                "cookie_secret": "c00ki3sekr1t",
+                "cookie_secret": u"c00ki3sekr1t",
+                "token_secret": b"t0k3ns3kr1t",
+                "use_jwt": False,
+                "salt": b"salt",
+            },
+            '"cookie_secret" config parameter must be bytes;'
+        ),
+        (
+            {
+                "cookie_service": "cookie.example.com",
+                "token_service": "token.example.com",
+                "cookie_secret": b"c00ki3sekr1t",
                 "token_secret": b"t0k3ns3kr1t",
                 "use_jwt": False,
                 "salt": u"salt",


### PR DESCRIPTION
I was looking at #491 and considering working on it, but it would involve modifying code in `authorizer.py`, which isn't especially well-tested. I wrote some stronger tests before I work on that patch.

In particular, there are better coverage of some error cases, and while working on it I cleaned up some of the authoriser code. It has more robust handling for JWT parsing errors, and I removed an unhittable branch.