### PR TITLE
tform.iteritems() to tform.items()

### DIFF
--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -379,7 +379,7 @@ class Loris(object):
         tforms = self.app_configs['transforms']
         source_formats = [k for k in tforms if isinstance(tforms[k], dict)]
         self.logger.debug('Source formats: %r', source_formats)
-        global_tranform_options = dict((k, v) for k, v in tforms.iteritems() if not isinstance(v, dict))
+        global_tranform_options = dict((k, v) for k, v in tforms.items() if not isinstance(v, dict))
         self.logger.debug('Global transform options: %r', global_tranform_options)
 
         transformers = {}


### PR DESCRIPTION
I needed to make this change as part of my python2 to python3 migration

```
ic| tforms: {'dither_bitonal_images': False,
             'jp2': {'impl': 'KakaduJP2Transformer',
                     'kdu_expand': '/Users/btingle/code/potto-loris/loris/bin/Darwin/x86_64/kdu_expand',
                     'kdu_libs': '/Users/btingle/code/potto-loris/loris/lib/Linux/x86_64',
                     'map_profile_to_srgb': False,
                     'mkfifo': '/usr/bin/mkfifo',
                     'num_threads': '4',
                     'srgb_profile_fp': '/usr/share/color/icc/colord/sRGB.icc',
                     'tmp_dp': '/Users/btingle/code/potto-loris/tmp'},
             'jpg': {'impl': 'JPG_Transformer'},
             'target_formats': ['jpg', 'png', 'gif', 'webp'],
             'tif': {'impl': 'TIF_Transformer'}}
Traceback (most recent call last):
  File "loris2.wsgi.py", line 82, in <module>
    'srgb_profile_fp': '/usr/share/color/icc/colord/sRGB.icc'
  File "/Users/btingle/code/potto-loris/loris/loris/webapp.py", line 368, in __init__
    self.transformers = self._load_transformers()
  File "/Users/btingle/code/potto-loris/loris/loris/webapp.py", line 384, in _load_transformers
    global_tranform_options = dict((k, v) for k, v in tforms.iteritems() if not isinstance(v, dict))
AttributeError: 'dict' object has no attribute 'iteritems'
```