### PR TITLE
Fix HTTP resolver caching for identifiers containing url-encodable characters

### DIFF
--- a/loris/resolver.py
+++ b/loris/resolver.py
@@ -277,6 +277,7 @@ class SimpleHTTPResolver(_AbstractResolver):
         return (url, self.request_options())
 
     def cache_dir_path(self, ident):
+        ident = unquote(ident)
         return join(
             self.cache_root,
             CacheNamer.cache_directory_name(ident=ident),


### PR DESCRIPTION
The HTTP resolver has been saving `unquote(ident)` keys in the cache, but looking up plain `ident`s. That's meant that, for some identifiers, it's found nothing in the cache until just before it saves - after the resolved file has been downloaded again. 

This PR fixes this behaviour by making sure to perform the `unquote` at the time of calculating the cache key. Since `unquote` is idempotent it doesn't break any existing code.