### PR TITLE
Configurable PIL.Image.MAX_IMAGE_PIXELS

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -54,6 +54,8 @@ Any options you add here will be passed through to the resolver you implement. F
 
 Probably safe to leave these as-is unless you care about something very specific. See the [Developer Notes](develop.md#image-transformations) for when this may not be the case. The exceptions are `kdu_expand` and `kdu_libs` in the `[transforms.jp2]` (see [Installing Dependencies](dependencies.md) step 2) or if you're not concerned about color profiles (see next).
 
+If you are seeing `DecompressionBombError`s thrown for very large source images, try setting the `pil_max_image_pixels` property here. This error occurs for images that are larger than 2x PIL's MAX_IMAGE_PIXELS property, which is `1024 * 1024 * 1024 // 4 // 3 = 89478485` by default (and so the error is thrown for images larger than `2 * 89478485 = 178956970` pixels).
+
 ### map_profile_to_srgb
 
 You can tell Loris to map embedded color profiles to sRGB with the following settings in your transformer:

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -56,6 +56,8 @@ Probably safe to leave these as-is unless you care about something very specific
 
 If you are seeing `DecompressionBombError`s thrown for very large source images, try setting the `pil_max_image_pixels` property here. This error occurs for images that are larger than **2x** PIL's MAX_IMAGE_PIXELS property, which is `1024 * 1024 * 1024 // 4 // 3 = 89478485` by default (and so the error is thrown for images larger than `2 * 89478485 = 178956970` pixels). Note that PIL will still log a `DecompressionBombWarning` will still be logged if the image is bigger than **1x** the configured value.
 
+If `pil_max_image_pixels` is set to `0`, `PIL.Image.MAX_IMAGE_PIXELS` is set to `None` and there is no limit on image size.
+
 ### map_profile_to_srgb
 
 You can tell Loris to map embedded color profiles to sRGB with the following settings in your transformer:

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -54,7 +54,7 @@ Any options you add here will be passed through to the resolver you implement. F
 
 Probably safe to leave these as-is unless you care about something very specific. See the [Developer Notes](develop.md#image-transformations) for when this may not be the case. The exceptions are `kdu_expand` and `kdu_libs` in the `[transforms.jp2]` (see [Installing Dependencies](dependencies.md) step 2) or if you're not concerned about color profiles (see next).
 
-If you are seeing `DecompressionBombError`s thrown for very large source images, try setting the `pil_max_image_pixels` property here. This error occurs for images that are larger than 2x PIL's MAX_IMAGE_PIXELS property, which is `1024 * 1024 * 1024 // 4 // 3 = 89478485` by default (and so the error is thrown for images larger than `2 * 89478485 = 178956970` pixels).
+If you are seeing `DecompressionBombError`s thrown for very large source images, try setting the `pil_max_image_pixels` property here. This error occurs for images that are larger than **2x** PIL's MAX_IMAGE_PIXELS property, which is `1024 * 1024 * 1024 // 4 // 3 = 89478485` by default (and so the error is thrown for images larger than `2 * 89478485 = 178956970` pixels). Note that PIL will still log a `DecompressionBombWarning` will still be logged if the image is bigger than **1x** the configured value.
 
 ### map_profile_to_srgb
 

--- a/etc/loris2.conf
+++ b/etc/loris2.conf
@@ -107,6 +107,11 @@ dither_bitonal_images = False
 # To enable TIFF output, add "tif" here:
 target_formats = ['jpg','png','gif','webp']
 
+# By default PIL throws a DecompressionBombError for images that are larger than 
+# 2x its MAX_IMAGE_PIXELS property (this limit is 2 * 89478485 = 178956970px).
+# This property can be overridden by this config value, eg:
+# pil_max_image_pixels = 250000000
+
     [[jpg]]
     impl = 'JPG_Transformer'
 

--- a/etc/loris2.conf
+++ b/etc/loris2.conf
@@ -109,7 +109,8 @@ target_formats = ['jpg','png','gif','webp']
 
 # By default PIL throws a DecompressionBombError for images that are larger than 
 # 2x its MAX_IMAGE_PIXELS property (this limit is 2 * 89478485 = 178956970px).
-# This property can be overridden by this config value, eg:
+# This property can be overridden by this config value. If set to 0, MAX_IMAGE_PIXELS
+# is set to `None` and there is no limit on image size.
 # pil_max_image_pixels = 250000000
 
     [[jpg]]

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -19,6 +19,7 @@ import sys
 sys.path.append('.')
 
 from configobj import ConfigObj
+from PIL import Image
 from werkzeug.http import parse_date, http_date
 
 from werkzeug.wrappers import (
@@ -379,13 +380,17 @@ class Loris(object):
         tforms = self.app_configs['transforms']
         source_formats = [k for k in tforms if isinstance(tforms[k], dict)]
         self.logger.debug('Source formats: %r', source_formats)
-        global_tranform_options = dict((k, v) for k, v in tforms.items() if not isinstance(v, dict))
-        self.logger.debug('Global transform options: %r', global_tranform_options)
+        global_transform_options = dict((k, v) for k, v in tforms.items() if not isinstance(v, dict))
+        self.logger.debug('Global transform options: %r', global_transform_options)
+
+        pil_max_image_pixels = tforms.get('pil_max_image_pixels', Image.MAX_IMAGE_PIXELS)
+        Image.MAX_IMAGE_PIXELS = pil_max_image_pixels
+        self.logger.debug('PIL maximum image pixels set to: %d', pil_max_image_pixels)
 
         transformers = {}
         for sf in source_formats:
             # merge [transforms] options and [transforms][source_format]] options
-            config = dict(list(self.app_configs['transforms'][sf].items()) + list(global_tranform_options.items()))
+            config = dict(list(self.app_configs['transforms'][sf].items()) + list(global_transform_options.items()))
             transformers[sf] = self._load_transformer(config)
         return transformers
 

--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -384,8 +384,12 @@ class Loris(object):
         self.logger.debug('Global transform options: %r', global_transform_options)
 
         pil_max_image_pixels = tforms.get('pil_max_image_pixels', Image.MAX_IMAGE_PIXELS)
-        Image.MAX_IMAGE_PIXELS = pil_max_image_pixels
-        self.logger.debug('PIL maximum image pixels set to: %d', pil_max_image_pixels)
+        if pil_max_image_pixels != 0:
+            Image.MAX_IMAGE_PIXELS = pil_max_image_pixels
+            self.logger.debug('PIL maximum image pixels set to: %d', pil_max_image_pixels)
+        else:
+            Image.MAX_IMAGE_PIXELS = None
+            self.logger.debug('PIL maximum image pixels limit removed.')
 
         transformers = {}
         for sf in source_formats:

--- a/tests/transforms_t.py
+++ b/tests/transforms_t.py
@@ -2,6 +2,7 @@ import unittest
 import operator
 
 import pytest
+from PIL.Image import DecompressionBombError
 
 from loris import transforms
 from loris.loris_exception import ConfigError
@@ -344,3 +345,11 @@ class Test_PILTransformer(loris_t.LorisTest,
         ident = 'png_with_transparency.png'
         request_path = '/%s/full/full/0/default.jpg' % ident
         self.request_image_from_client(request_path)
+
+    def test_respects_pil_max_image_pixels(self):
+        config = get_debug_config('kdu')
+        config['transforms']['pil_max_image_pixels'] = 1
+        self.build_client_from_config(config)
+        with pytest.raises(DecompressionBombError):
+            request_path = '/%s/full/300,300/0/default.jpg' % self.ident
+            self.request_image_from_client(request_path)

--- a/tests/transforms_t.py
+++ b/tests/transforms_t.py
@@ -2,7 +2,7 @@ import unittest
 import operator
 
 import pytest
-from PIL.Image import DecompressionBombError
+from PIL import Image
 
 from loris import transforms
 from loris.loris_exception import ConfigError
@@ -347,9 +347,15 @@ class Test_PILTransformer(loris_t.LorisTest,
         self.request_image_from_client(request_path)
 
     def test_respects_pil_max_image_pixels(self):
-        config = get_debug_config('kdu')
-        config['transforms']['pil_max_image_pixels'] = 1
-        self.build_client_from_config(config)
-        with pytest.raises(DecompressionBombError):
-            request_path = '/%s/full/300,300/0/default.jpg' % self.ident
-            self.request_image_from_client(request_path)
+        default_max_pixels = Image.MAX_IMAGE_PIXELS
+        try:
+            config = get_debug_config('kdu')
+            config['transforms']['pil_max_image_pixels'] = 1
+            self.build_client_from_config(config)
+            with pytest.raises(Image.DecompressionBombError):
+                request_path = '/%s/full/300,300/0/default.jpg' % self.ident
+                self.request_image_from_client(request_path)
+        finally:
+            # Because we have to mutate a value in an external library
+            # it must be reset at the end of this test
+            Image.MAX_IMAGE_PIXELS = default_max_pixels


### PR DESCRIPTION
As suggested in https://github.com/loris-imageserver/loris/issues/289, this adds a config option to override PIL's `Image.MAX_IMAGE_PIXELS`, therefore giving Loris users a way of avoiding `DecompressionBombError`s for very large source images.

Resolves https://github.com/loris-imageserver/loris/issues/289