### PR TITLE
Ubuntu 20 docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![loris icon](www/icons/loris-circle-small.png?raw=true) Loris IIIF Image Server
+![loris icon](loris/data/www/icons/loris-circle-small.png?raw=true) Loris IIIF Image Server
 =============================================================================
 
 Loris is an implementation of the [IIIF Image API 2.0](http://iiif.io/api/image/2.0/).

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -1,7 +1,7 @@
 Installing Dependencies
 =======================
 
-These instructions are known to work with Ubuntu 14.04 and Ubuntu 16.04. If you have further information, please provide it!
+These instructions are known to work with Ubuntu 14.04 and Ubuntu 16.04. Instructions for Ubuntu 20.04 are listed separately below where they differ. If you have further information, please provide it!
 
 Loris (Pillow, actually, with the exception of Kakadu) depends on several external libraries that can't be installed with pip, so there are few steps that must be carefully followed to get going. Installing the dependencies manually is a good idea if you want to run the tests.
 
@@ -16,6 +16,12 @@ If you are deploying on a different system or architecture, you can [Download th
 [`pip`](https://pip.pypa.io/en/latest/index.html) is used to install dependencies; [`setuptools`](https://pypi.python.org/pypi/setuptools) is used to install Loris.
 
     $ sudo apt-get install python-pip python-setuptools
+
+For Ubuntu 20:
+
+    $ sudo apt update              # Do not skip this step
+    $ sudo apt install python3-pip # No need to install python3-setuptools
+    $ pip3 --version               # Verify that PIP is installed
 
 ### Install Pillow
 
@@ -39,6 +45,10 @@ For CentOS:
 Now install Pillow (setup.py would do this for you, but it's better to do separately and check):
 
     $ sudo pip install Pillow
+
+For Ubuntu 20:
+    
+    $sudo pip3 install Pillow
 
 In case you plan on working on the source code without running setup.py, the following are required python libraries that must currently exist in your Python environment:
 

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -11,7 +11,7 @@ This user needs to have a home directory (unless you want to override it in the 
 
 Finally, from the `loris` (not `loris/loris`) directory, either as root or with `sudo` run `./setup.py install` with the options of your choice.
 
-Note: on Ubuntu 20 you might have to run `python3 setup.py install` instead.
+Note: on Ubuntu 20 you might have to run `sudo python3 setup.py install` instead.
 
 There are a bunch of flags that can be passed to `setup.py install` to customize where things wind up. Assuming you run `setup.py` with appropriate permissions (probably root), the script will make any directories that don't exist and set the ownership and permissions appropriately.
 

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -9,13 +9,18 @@ $ sudo adduser loris
 
 This user needs to have a home directory (unless you want to override it in the WSGI [`home=` directive](https://code.google.com/p/modwsgi/wiki/ConfigurationDirectives#WSGIDaemonProcess)) and the user and group name should match the `run_as_user` and `run_as_group` options in the `[loris.Loris]` section of `loris2.conf` and the `--loris-owner` and `--loris-group` options that you pass to `setup.py` (see below).
 
-Finally, from the `loris` (not `loris/loris`) directory, either as root or with `sudo` run `./setup.py install` with the options of your choice.
+Finally, from the `loris` (not `loris/loris`) directory, run
 
-Note: on Ubuntu 20 you might have to run `sudo python3 setup.py install` instead.
+    $ sudo ./setup.py install
 
-There are a bunch of flags that can be passed to `setup.py install` to customize where things wind up. Assuming you run `setup.py` with appropriate permissions (probably root), the script will make any directories that don't exist and set the ownership and permissions appropriately.
+with the options of your choice.
 
-These are the options (they can also be viewed by executing `python setup.py install --help`):
+For Ubuntu 20:
+
+    $ sudo python3 ./setup.py install
+
+There are a bunch of flags that can be passed to `setup.py install` to customize where things wind up:
+
 
 ```
  --kdu-expand      Path to the Kakadu executable [Default: /usr/local/bin/kdu_expand]
@@ -32,6 +37,18 @@ These are the options (they can also be viewed by executing `python setup.py ins
 ```
 
 All of these will be updated in the config file during deployment.
+
+After running `setup.py`, you have to run:
+
+    $ sudo ./bin/setup_directories.py 
+    
+This script will then create any directories that don't exist and set the ownership and permissions appropriately.
+
+For Ubuntu 20:
+
+    $ sudo python3 ./bin/setup_directories.py
+
+The `loris2.wsgi` WSGI file should now have been created and can be found in the directory that is configured as the `www_dp` directory in the `loris2.conf` file (by default: `/var/www/loris2`).
 
 Note again that __Kakadu is no longer installed__ by the setup script; it didn't work for too many people. You may use the copy that is bundled with Loris, provided you comply with the [terms outlined by NewSouth Innovations](http://www.kakadusoftware.com/index.php?option=com_content&task=view&id=26&Itemid=22) and this version works on your system. Either of these may well not be the case, in which case you will need to obtain a copy of Kakadu 7+ separately and may need to compile it for your system.
 

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -7,11 +7,13 @@ Create a user that will own the loris application, e.g.:
 $ sudo adduser loris
 ```
 
-This user needs to have a home directory (unless you want to override it in the WSGI [`home=` directive](https://code.google.com/p/modwsgi/wiki/ConfigurationDirectives#WSGIDaemonProcess)) and the user and group name should match the `run_as_user` and `run_as_group` options of in the `[loris.Loris]` section of `loris2.conf` and the `--loris-owner` and `--loris-group` options that you pass to `setup.py` (see beloq)..
+This user needs to have a home directory (unless you want to override it in the WSGI [`home=` directive](https://code.google.com/p/modwsgi/wiki/ConfigurationDirectives#WSGIDaemonProcess)) and the user and group name should match the `run_as_user` and `run_as_group` options in the `[loris.Loris]` section of `loris2.conf` and the `--loris-owner` and `--loris-group` options that you pass to `setup.py` (see below).
 
 Finally, from the `loris` (not `loris/loris`) directory, either as root or with `sudo` run `./setup.py install` with the options of your choice.
 
-There are a bunch of flag that can be passed to `setup.py install` to customize where things wind up. Assuming you run `setup.py` with appropriate permissions (probably root), the script will make any directories that don't exist and set the ownership and permissions appropriately.
+Note: on Ubuntu 20 you might have to run `python3 setup.py install` instead.
+
+There are a bunch of flags that can be passed to `setup.py install` to customize where things wind up. Assuming you run `setup.py` with appropriate permissions (probably root), the script will make any directories that don't exist and set the ownership and permissions appropriately.
 
 These are the options (they can also be viewed by executing `python setup.py install --help`):
 
@@ -31,7 +33,7 @@ These are the options (they can also be viewed by executing `python setup.py ins
 
 All of these will be updated in the config file during deployment.
 
-Note that again that __Kakadu is no longer installed__ by the setup script; it didn't work for too many people. You may use the copy that is bundled with Loris, provided you comply with the [terms outlined by NewSouth Innovations](http://www.kakadusoftware.com/index.php?option=com_content&task=view&id=26&Itemid=22) and this version works on your system. Either of these may well not be the case, in which case you will need to obtain a copy of Kakadu 7+ separately and may need to compile it for your system.
+Note again that __Kakadu is no longer installed__ by the setup script; it didn't work for too many people. You may use the copy that is bundled with Loris, provided you comply with the [terms outlined by NewSouth Innovations](http://www.kakadusoftware.com/index.php?option=com_content&task=view&id=26&Itemid=22) and this version works on your system. Either of these may well not be the case, in which case you will need to obtain a copy of Kakadu 7+ separately and may need to compile it for your system.
 
 
 * * *


### PR DESCRIPTION
Add instructions for Ubuntu 20 to docs. Slightly restructure instructions for better clarity. Add paragraph about running setup_directories.py script. Add paragraph about where the generated WSGI file can be found. Fix typos.