### PR TITLE
Use sane environment by default

### DIFF
--- a/loris/webapp.py
+++ b/loris/webapp.py
@@ -47,6 +47,7 @@ def get_default_config():
     config_file_path = path.join(data_directory, 'loris.conf')
 
     config = read_config(config_file_path)
+    config['data_directory'] = data_directory
 
     if "logging" not in config:
         config['logging'] = get_default_logging()
@@ -64,7 +65,7 @@ def get_debug_config(debug_jp2_transformer):
     config = get_default_config()
 
     # override some stuff to look at relative or tmp directories.
-    config['loris.Loris']['www_dp'] = path.join(data_directory, 'www')
+    config['loris.Loris']['www_dp'] = path.join(config['data_directory'], 'www')
     config['loris.Loris']['tmp_dp'] = '/tmp/loris/tmp'
     config['loris.Loris']['enable_caching'] = True
     config['img.ImageCache']['cache_dp'] = '/tmp/loris/cache/img'


### PR DESCRIPTION
 - by default, the repository has debug enabled, meaning the get_debug_config is called
   overwriting the user config. That is not nice. Changed by default to false.
   In the future this can be a configuration flag?

 - when no config file is set, and debug is false, no configuration is loaded. This causes
   a lot of errors (namely key not founds). Given the repo includes a config file, added
   code to load it by default

 - when using the default config file, warn the user about that

Some details can be made better, but for now, it is working perfectly on my docker environment.
I am happy to provide further changes on this branch if you like.