### PR TITLE
Fixing incorrect path to conf file

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,7 +1,7 @@
 Configuration and Options
 =========================
 
-See `etc/loris.conf`.
+See `loris/data/loris.conf`.
 
 In addition to a bunch of directory paths (items that end with `_dp`) which should be self-explanatory and the [transformation options explained below](#image-transformations), there are some options:
 


### PR DESCRIPTION
Documentation says that loris.conf is at etc/loris.conf. It's actually in loris/data/loris.conf