### PR TITLE
Drop support for old Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Demos
 
 Installation Instructions
 -------------------------
-Loris is supported on Python 3.6+. If you need to use Python 2.7 or Python 3.4, Loris v2.3.3 is the last version to support it.
+Loris is supported on Python 3.7+. If you need to use old Python versions, Loris v2.3.3 is the last version to support it.
 
 If you want to run Loris on Ubuntu 20, use Loris v3.1.0 or later.
 


### PR DESCRIPTION
Python 3.6 is an old unsupported Python version.
Remove it in GitHub action and update documentation to mention only Python versions with active support.